### PR TITLE
Create config folder if missing

### DIFF
--- a/packages/mdctl-cli/mdctl.js
+++ b/packages/mdctl-cli/mdctl.js
@@ -118,10 +118,15 @@ module.exports = class MdCtlCli {
 
     const privates = privatesAccessor(this),
           config = createConfig(),
-          keyProvider = new KeytarCredentialsProvider('com.medable.mdctl')
+          keyProvider = new KeytarCredentialsProvider('com.medable.mdctl'),
+          configureDir = path.join(os.homedir(), '.medable')
 
     let encryptionKey = await keyProvider.getCustom('pouchKey', '*'),
         env = privates.args('env')
+
+    if (!fs.existsSync(configureDir)) {
+      fs.mkdirSync(configureDir, {recursive: true})
+    }
 
     if (!encryptionKey) {
       encryptionKey = randomAlphaNumSym(32)
@@ -129,7 +134,7 @@ module.exports = class MdCtlCli {
     }
 
     privates.credentialsProvider = new PouchDbCredentialsProvider({
-      name: path.join(os.homedir(), '.medable/mdctl.db'),
+      name: path.join(configureDir, 'mdctl.db'),
       key: encryptionKey
     })
 
@@ -137,7 +142,7 @@ module.exports = class MdCtlCli {
 
     // read program config, prefs, then local overrides
     await readConfig(config, path.join(__dirname, './.mdctl.yaml'))
-    await readConfig(config, path.join(os.homedir(), '.medable', 'mdctl.yaml'))
+    await readConfig(config, path.join(configureDir, 'mdctl.yaml'))
     await readConfig(config, path.join(__dirname, './.mdctl.local.yaml'))
 
     // ensure an environment is selected
@@ -149,7 +154,7 @@ module.exports = class MdCtlCli {
 
     // load environment defaults then reset overrides
     await readConfig(config, path.join(__dirname, 'environments', `${env}.yaml`))
-    await readConfig(config, path.join(os.homedir(), '.medable', 'mdctl.yaml'))
+    await readConfig(config, path.join(configureDir, 'mdctl.yaml'))
     await readConfig(config, path.join(__dirname, './mdctl.local.yaml'))
 
     // ensure correct env is still selected

--- a/packages/mdctl-credentials-provider-pouchdb/index.js
+++ b/packages/mdctl-credentials-provider-pouchdb/index.js
@@ -7,8 +7,6 @@ const PouchDB = require('pouchdb-core')
         createCipheriv, createDecipheriv, listCiphers
       } = require('browserify-aes'),
       createHash = require('create-hash'),
-      fs = require('fs'),
-      path = require('path'),
       randomBytes = require('randombytes'),
       { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
       { isSet, rString, rPath } = require('@medable/mdctl-core-utils/values'),
@@ -136,10 +134,6 @@ class PouchDbCredentialsProvider extends CredentialsProvider {
       let err
 
       try {
-        const configDir = path.dirname(name)
-        if (!fs.existsSync(configDir)) {
-          fs.mkdirSync(configDir)
-        }
 
         db = new PouchDB(name, { adapter: 'websql', auto_compaction: true, revs_limit: 0 })
 

--- a/packages/mdctl-credentials-provider-pouchdb/index.js
+++ b/packages/mdctl-credentials-provider-pouchdb/index.js
@@ -7,6 +7,8 @@ const PouchDB = require('pouchdb-core')
         createCipheriv, createDecipheriv, listCiphers
       } = require('browserify-aes'),
       createHash = require('create-hash'),
+      fs = require('fs'),
+      path = require('path'),
       randomBytes = require('randombytes'),
       { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
       { isSet, rString, rPath } = require('@medable/mdctl-core-utils/values'),
@@ -134,6 +136,10 @@ class PouchDbCredentialsProvider extends CredentialsProvider {
       let err
 
       try {
+        const configDir = path.dirname(name)
+        if (!fs.existsSync(configDir)) {
+          fs.mkdirSync(configDir)
+        }
 
         db = new PouchDB(name, { adapter: 'websql', auto_compaction: true, revs_limit: 0 })
 


### PR DESCRIPTION
Gracefully handles the case where `~/.medable` directory does not exist; automatically creates directory.  This stops credentials commands from throwing errors such as...

```
› mdctl credentials add
? Which type of credentials are you using? Password - Email/Username and Password
? The api endpoint (example: https://api.dev.medable.com) blah.medable.com
? The env (org code) myorgcode
? The account username myemail
? The account password [hidden]
? The api key somekeysahkbfdhas
events.js:173
      throw er; // Unhandled 'error' event
      ^

error: SQLITE_CANTOPEN: unable to open database file
Emitted 'error' event at:

```