### PR TITLE
add check for `transform.writable` before writing

### DIFF
--- a/packages/mdctl-api/adapters/index.js
+++ b/packages/mdctl-api/adapters/index.js
@@ -77,7 +77,10 @@ function readerToTransform(response) {
 
           // do something with the current chunk
           const chunk = result.value
-          transform.write(chunk)
+
+          if (transform.writable === true) {
+            transform.write(chunk)
+          }
 
           return consume(responseReader)
         })


### PR DESCRIPTION
When cancelling a stream using `stream.destroy` I encountered the following error:

```
_stream_writable.js?2135:288 Uncaught (in promise) error: write after end
    at writeAfterEnd (webpack-internal:///../../node_modules/readable-stream/lib/_stream_writable.js:288:12)
    at TransformStream.Writable.write (webpack-internal:///../../node_modules/readable-stream/lib/_stream_writable.js:332:20)
    at eval (webpack-internal:///../../node_modules/@medable/mdctl-api/adapters/index.js:119:17)
```

This pr adds check for `transform.writable` before writing, which seems to fix the issue 