### PR TITLE
Improve issues-report messages

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-67/MIG-67.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-67/MIG-67.test.js
@@ -94,8 +94,8 @@ describe('StudyManifestTools', () => {
     expect(issues).toHaveLength(2)
     expect(issues)
       .toStrictEqual([
-        'Entity not found in export for c_patient_flag 615bcd016631cc0100d2766c for reference c_boolean_step id 615bca961a20230100471c01',
-        'Entity not found in export for c_patient_flag 615bcd016631cc0100d2766c for reference c_task_completion id 615b60d1bf2e4301008f4d77'
+        "The object c_patient_flag (615bcd016631cc0100d2766c) is removed from export because it depends on c_boolean_step (615bca961a20230100471c01) which doesn't exist",
+        "The object c_patient_flag (615bcd016631cc0100d2766c) is removed from export because it depends on c_task_completion (615b60d1bf2e4301008f4d77) which doesn't exist"
       ])
 
   })

--- a/packages/mdctl-axon-tools/__tests__/TOOLS-42/TOOLS-42.test.js
+++ b/packages/mdctl-axon-tools/__tests__/TOOLS-42/TOOLS-42.test.js
@@ -397,7 +397,7 @@ describe('StudyManifestTools', () => {
     expect(issues)
       .toStrictEqual([
         'No entity id for c_some_entity 60ca0d6c10f3800100661d0a for reference c_study',
-        'Entity not found in export for c_some_entity 60ca0d6c10f3800100661d0a for reference c_visits id 611fe3cf6db3df0100238e01'
+        "The object c_some_entity (60ca0d6c10f3800100661d0a) is removed from export because it depends on c_visits (611fe3cf6db3df0100238e01) which doesn't exist"
       ])
 
   })

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -474,7 +474,7 @@ class StudyManifestTools {
           const refEntity = entities.find(v => v._id === refEntityId)
 
           if (!refEntity) {
-            const issue = `Entity not found in export for ${entity.object} ${entity._id} for reference ${subReference} id ${refEntityId}`
+            const issue = `The object ${entity.object} (${entity._id}) is removed from export because it depends on ${subReference} (${refEntityId}) which doesn't exist`
             issues.push(issue)
           }
         })


### PR DESCRIPTION
Improve issues report logs, to make it clear that objects that depend on a missing object will not be exported.