### PR TITLE
Draft: MIG-109: split function getStudyManifest as per requirement

### DIFF
--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -124,20 +124,39 @@ class StudyManifestTools {
 
   async getStudyManifest() {
     console.log('Building Manifest')
+    const manifestAndDeps = await this.buildManifestAndDependencies()
+    await this.writeToDisk(manifestAndDeps)
+    return manifestAndDeps
+  }
+
+  async buildManifestAndDependencies() {
     const { client } = privatesAccessor(this),
           driver = new Driver(client),
           org = new Org(driver),
           // eslint-disable-next-line camelcase
           { c_study } = org.objects,
-          study = await c_study.readOne()
-            .execute(),
+          study = await c_study.readOne().execute(),
           { orgReferenceProps } = await this.getOrgObjectInfo(org),
+          // eslint-disable-next-line max-len
           allEntities = [study, ...await this.getStudyManifestEntities(org, study, orgReferenceProps)],
+          // eslint-disable-next-line max-len
           { outputEntities, removedEntities } = this.validateReferences(allEntities, orgReferenceProps),
           manifest = this.createManifest(outputEntities),
           menuConfigMapping = new MenuConfigMapping(org),
-          mappingScript = await menuConfigMapping.getMappingScript()
+          mappingScript = await menuConfigMapping.getMappingScript(),
+          ingestTransform = fs.readFileSync('../packageScripts/ingestTransform.js')
 
+    return {
+      manifest,
+      removedEntities,
+      mappingScript,
+      ingestTransform: ingestTransform.toString()
+    }
+  }
+
+  async writeToDisk({
+    manifest, removedEntities, mappingScript, ingestTransform
+  }) {
     let extraConfig
 
     if (mappingScript) {
@@ -146,8 +165,6 @@ class StudyManifestTools {
 
     this.writeIssues(removedEntities)
     this.writePackage('study', extraConfig)
-
-    return { manifest, removedEntities }
   }
 
   writeInstallAfterScript(mappingScript) {


### PR DESCRIPTION
Requirements:
- [MIG-109](https://jira.devops.medable.com/browse/MIG-109)

Note:
- This change is necessary for [AXD-46](https://jira.devops.medable.com/browse/AXD-46). The current logic of getStudyManifest function in StudyManifestTools module will be split into 2 new functions called buildManifestAndDependencies and writeToDisk; the former function will generate all relevant data objects and the latter will write files on the disk.