### PR TITLE
MIG-109: split getStudyManifest function as per requirement

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
@@ -29,6 +29,51 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
           _id: '615b60d1bf2e4301008f4d68',
           object: 'c_dummy_object',
           c_key: 'key-002'
+        },
+        {
+          _id: '619aaaafe44c6e01003f7313',
+          object: 'c_task',
+          c_key: 'key-003'
+        },
+        {
+          _id: '61981246ca9563010037bfa8',
+          object: 'c_task',
+          c_key: 'key-004'
+        },
+        {
+          _id: '61981246ca95714c14e61a8c',
+          object: 'c_step',
+          c_key: 'key-005'
+        },
+        {
+          _id: '61981246ca966caef6108f28',
+          object: 'c_step',
+          c_key: 'key-006'
+        },
+        {
+          _id: '61981246ca9592ee0e41a3dd',
+          object: 'ec__document_template',
+          c_key: 'key-007'
+        },
+        {
+          _id: '61980eb292466ea32e087378',
+          object: 'ec__document_template',
+          c_key: 'key-008'
+        },
+        {
+          _id: '6d525cf2e328e7300d97c399',
+          object: 'ec__default_document_css',
+          c_key: 'key-009'
+        },
+        {
+          _id: '6d525cfe328e64ac0833baef',
+          object: 'ec__knowledge_check',
+          c_key: 'key-010'
+        },
+        {
+          _id: '6d525f2e328e7f1e48262523',
+          object: 'ec__knowledge_check',
+          c_key: 'key-011'
         }],
         dummyReferences = [
           {
@@ -36,13 +81,6 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
             array: false,
             object: 'c_study',
             type: 'Reference',
-            required: false
-          },
-          {
-            name: 'c_visits',
-            array: true,
-            object: 'c_visit',
-            type: 'ObjectId',
             required: false
           }
         ],
@@ -73,22 +111,6 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
               })
             }
           }
-        },
-        manifest = {
-          object: 'manifest',
-          dependencies: false,
-          exportOwner: false,
-          importOwner: false,
-          c_study: {
-            includes: [
-              'key-001'
-            ]
-          },
-          c_dummy_object: {
-            includes: [
-              'key-002'
-            ]
-          }
         }
 
   beforeAll(async() => {
@@ -100,14 +122,44 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
     jest.clearAllMocks()
   })
 
-  it('Test buildManifestAndDependencies function', async() => {
+  it('Test study manifest creation', async() => {
+    const manifest = {
+            object: 'manifest',
+            dependencies: false,
+            exportOwner: false,
+            importOwner: false,
+            c_study: {
+              includes: [
+                'key-001'
+              ]
+            },
+            c_dummy_object: {
+              includes: [
+                'key-002'
+              ]
+            },
+            c_task: {
+              includes: [
+                'key-003',
+                'key-004'
+              ]
+            },
+            c_step: {
+              includes: [
+                'key-005',
+                'key-006'
+              ]
+            }
+          },
+          ingestTransform = fs.readFileSync(`${__dirname}/../../packageScripts/ingestTransform.js`).toString()
+
     jest.spyOn(StudyManifestTools.prototype, 'getFirstStudy').mockImplementation(() => org)
     jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
     jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
     jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)
 
-    const ingestTransform = fs.readFileSync(`${__dirname}/../../packageScripts/ingestTransform.js`).toString(),
-          manifestAndDeps = await manifestTools.buildManifestAndDependencies()
+    // eslint-disable-next-line one-var
+    const manifestAndDeps = await manifestTools.buildManifestAndDependencies()
 
     expect(manifestAndDeps.manifest)
       .toStrictEqual(manifest)
@@ -117,5 +169,75 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
       .toBeUndefined()
     expect(manifestAndDeps.ingestTransform)
       .toStrictEqual(ingestTransform)
+  })
+
+  it('Test task manifest creation', async() => {
+    const manifest = {
+      object: 'manifest',
+      dependencies: false,
+      exportOwner: false,
+      importOwner: false,
+      c_task: {
+        includes: [
+          'key-003',
+          'key-004'
+        ]
+      },
+      c_step: {
+        includes: [
+          'key-005',
+          'key-006'
+        ]
+      }
+    }
+
+    jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
+    jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
+    jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)
+
+    // eslint-disable-next-line one-var
+    const manifestAndDeps = await manifestTools.buildTaskManifestAndDependencies(['619aaaafe44c6e01003f7313', '61981246ca9563010037bfa8'])
+
+    expect(manifestAndDeps.manifest)
+      .toStrictEqual(manifest)
+    expect(manifestAndDeps.removedEntities)
+      .toBeUndefined()
+  })
+
+  it('Test consent manifest creation', async() => {
+    const manifest = {
+      object: 'manifest',
+      dependencies: false,
+      exportOwner: false,
+      importOwner: false,
+      ec__document_template: {
+        includes: [
+          'key-007',
+          'key-008'
+        ]
+      },
+      ec__default_document_css: {
+        includes: [
+          'key-009'
+        ]
+      },
+      ec__knowledge_check: {
+        includes: [
+          'key-010',
+          'key-011'
+        ]
+      }
+    }
+    jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
+    jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
+    jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)
+
+    // eslint-disable-next-line one-var
+    const manifestAndDeps = await manifestTools.buildConsentManifestAndDependencies(['61981246ca9592ee0e41a3dd', '61980eb292466ea32e087378'])
+
+    expect(manifestAndDeps.manifest)
+      .toStrictEqual(manifest)
+    expect(manifestAndDeps.removedEntities)
+      .toBeUndefined()
   })
 })

--- a/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
@@ -101,7 +101,7 @@ describe('MIG-109 - Test StudyManifestTools ', () => {
   })
 
   it('Test buildManifestAndDependencies function', async() => {
-    jest.spyOn(StudyManifestTools.prototype, 'getOneStudy').mockImplementation(() => org)
+    jest.spyOn(StudyManifestTools.prototype, 'getFirstStudy').mockImplementation(() => org)
     jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
     jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
     jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)

--- a/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-109/MIG-109.test.js
@@ -1,0 +1,121 @@
+/* eslint-disable import/order */
+
+jest.mock('@medable/mdctl-api-driver', () => ({ Driver: class {} }), { virtual: true })
+jest.mock('@medable/mdctl-api-driver/lib/cortex.object', () => ({ Object: class {}, Org: class {} }), { virtual: true })
+jest.mock('../../lib/mappings')
+
+const fs = require('fs'),
+      StudyManifestTools = require('../../lib/StudyManifestTools')
+
+describe('MIG-109 - Test StudyManifestTools ', () => {
+
+  let manifestTools
+  const mockGetExportedObjects = jest.fn(() => []),
+        existingStudy = {
+          _id: '1',
+          c_name: 'Study',
+          c_key: 'abc'
+        },
+        hasNextStudyMock = jest.fn(() => true),
+        nextStudyMock = jest.fn(() => existingStudy),
+        hasNextStudySchema = jest.fn(() => true),
+        nextStudySchemaMock = jest.fn(() => ({ _id: '1', object: 'object', properties: [{ name: 'c_no_pii' }] })),
+        entities = [{
+          _id: '615bcd016631cc0100d2766c',
+          object: 'c_study',
+          c_key: 'key-001'
+        },
+        {
+          _id: '615b60d1bf2e4301008f4d68',
+          object: 'c_dummy_object',
+          c_key: 'key-002'
+        }],
+        dummyReferences = [
+          {
+            name: 'c_study',
+            array: false,
+            object: 'c_study',
+            type: 'Reference',
+            required: false
+          },
+          {
+            name: 'c_visits',
+            array: true,
+            object: 'c_visit',
+            type: 'ObjectId',
+            required: false
+          }
+        ],
+        org = {
+          objects: {
+            c_study: {
+              readOne: () => ({
+                skipAcl: () => ({
+                  grant: () => ({
+                    paths: () => ({
+                      hasNext: hasNextStudyMock,
+                      next: nextStudyMock
+                    })
+                  })
+                })
+              })
+            },
+            object: {
+              find: () => ({
+                skipAcl: () => ({
+                  grant: () => ({
+                    paths: () => ({
+                      hasNext: hasNextStudySchema,
+                      next: nextStudySchemaMock
+                    })
+                  })
+                })
+              })
+            }
+          }
+        },
+        manifest = {
+          object: 'manifest',
+          dependencies: false,
+          exportOwner: false,
+          importOwner: false,
+          c_study: {
+            includes: [
+              'key-001'
+            ]
+          },
+          c_dummy_object: {
+            includes: [
+              'key-002'
+            ]
+          }
+        }
+
+  beforeAll(async() => {
+    manifestTools = new StudyManifestTools({})
+    manifestTools.getExportObjects = mockGetExportedObjects
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Test buildManifestAndDependencies function', async() => {
+    jest.spyOn(StudyManifestTools.prototype, 'getOneStudy').mockImplementation(() => org)
+    jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
+    jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
+    jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)
+
+    const ingestTransform = fs.readFileSync(`${__dirname}/../../packageScripts/ingestTransform.js`).toString(),
+          manifestAndDeps = await manifestTools.buildManifestAndDependencies()
+
+    expect(manifestAndDeps.manifest)
+      .toStrictEqual(manifest)
+    expect(manifestAndDeps.removedEntities)
+      .toBeUndefined()
+    expect(manifestAndDeps.mappingScript)
+      .toBeUndefined()
+    expect(manifestAndDeps.ingestTransform)
+      .toStrictEqual(ingestTransform)
+  })
+})

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -130,7 +130,7 @@ class StudyManifestTools {
     return manifestAndDeps
   }
 
-  async getOneStudy(org) {
+  async getFirstStudy(org) {
     const study = await org.objects.c_study.readOne().execute()
     return study
   }
@@ -139,7 +139,7 @@ class StudyManifestTools {
     const { client } = privatesAccessor(this),
           driver = new Driver(client),
           org = new Org(driver),
-          study = await this.getOneStudy(org),
+          study = await this.getFirstStudy(org),
           { orgReferenceProps } = await this.getOrgObjectInfo(org),
           allEntities = [study, ...await this.getStudyManifestEntities(org, study, orgReferenceProps)],
           { outputEntities, removedEntities } = this.validateReferences(allEntities, orgReferenceProps),

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -130,20 +130,22 @@ class StudyManifestTools {
     return manifestAndDeps
   }
 
+  async getOneStudy(org) {
+    const study = await org.objects.c_study.readOne().execute()
+    return study
+  }
+
   async buildManifestAndDependencies() {
     const { client } = privatesAccessor(this),
           driver = new Driver(client),
           org = new Org(driver),
-          // eslint-disable-next-line camelcase
-          { c_study } = org.objects,
-          study = await c_study.readOne()
-            .execute(),
+          study = await this.getOneStudy(org),
           { orgReferenceProps } = await this.getOrgObjectInfo(org),
           allEntities = [study, ...await this.getStudyManifestEntities(org, study, orgReferenceProps)],
           { outputEntities, removedEntities } = this.validateReferences(allEntities, orgReferenceProps),
           manifest = this.createManifest(outputEntities),
           mappingScript = await getMappingScript(org),
-          ingestTransform = fs.readFileSync('../packageScripts/ingestTransform.js')
+          ingestTransform = fs.readFileSync(`${__dirname}/../packageScripts/ingestTransform.js`)
 
     return {
       manifest,
@@ -153,7 +155,9 @@ class StudyManifestTools {
     }
   }
 
-  async writeToDisk({ manifest, removedEntities, mappingScript, ingestTransform }) {
+  async writeToDisk({
+    manifest, removedEntities, mappingScript, ingestTransform
+  }) {
     let extraConfig
 
     if (mappingScript) {

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -12,7 +12,6 @@ const fs = require('fs'),
       { Fault } = require('@medable/mdctl-core')
 const { isObject, isArray } = require('lodash')
 const { getMappingScript } = require('./mappings')
-const MenuConfigMapping = require('./mappings/MenuConfigMapping')
 
 class StudyManifestTools {
 
@@ -137,15 +136,13 @@ class StudyManifestTools {
           org = new Org(driver),
           // eslint-disable-next-line camelcase
           { c_study } = org.objects,
-          study = await c_study.readOne().execute(),
+          study = await c_study.readOne()
+            .execute(),
           { orgReferenceProps } = await this.getOrgObjectInfo(org),
-          // eslint-disable-next-line max-len
           allEntities = [study, ...await this.getStudyManifestEntities(org, study, orgReferenceProps)],
-          // eslint-disable-next-line max-len
           { outputEntities, removedEntities } = this.validateReferences(allEntities, orgReferenceProps),
           manifest = this.createManifest(outputEntities),
-          menuConfigMapping = new MenuConfigMapping(org),
-          mappingScript = await menuConfigMapping.getMappingScript(),
+          mappingScript = await getMappingScript(org),
           ingestTransform = fs.readFileSync('../packageScripts/ingestTransform.js')
 
     return {
@@ -156,9 +153,7 @@ class StudyManifestTools {
     }
   }
 
-  async writeToDisk({
-    manifest, removedEntities, mappingScript, ingestTransform
-  }) {
+  async writeToDisk({ manifest, removedEntities, mappingScript, ingestTransform }) {
     let extraConfig
 
     if (mappingScript) {


### PR DESCRIPTION
Requirements
- [MIG-109](https://jira.devops.medable.com/browse/MIG-109)

Notes
- This is necessary for [AXD-46](https://jira.devops.medable.com/browse/AXD-46). The current logic of getStudyManifest function in StudyManifestTools module will be split into 2 new functions called buildManifestAndDependencies and writeToDisk; the former function will generate all relevant data objects and the latter will write files on the disk.