### PR TITLE
Draft: Caching issue when running source & target env snapshots in parallel

### DIFF
--- a/packages/mdctl-api-driver/lib/cortex.object.js
+++ b/packages/mdctl-api-driver/lib/cortex.object.js
@@ -15,16 +15,23 @@ const { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
         BulkOperation
       } = require('./operations'),
       { QueryCursor, AggregationCursor } = require('./cursor')
-      // registeredObjects = {},
-      // registeredAliases = {}
+
 
 class CortexObject {
 
   constructor(objectName, driver) {
 
-    Object.defineProperty(this, 'name', {
-      value: objectName.toLowerCase(),
-      enumerable: true
+    Object.defineProperties(this, {
+      name: {
+        value: objectName.toLowerCase(),
+        enumerable: true
+      },
+      registeredObjects: {
+        value: {}
+      },
+      registeredAliases: {
+        value: {}
+      }
     })
 
     Object.assign(privatesAccessor(this), {
@@ -32,14 +39,14 @@ class CortexObject {
     })
   }
 
-  /*
+
   registerObject(name, cls, ...aliases) {
     [name, ...aliases].map(n => n.toLowerCase()).forEach((alias) => {
       this.registeredAliases[alias] = name
     })
     this.registeredObjects[name] = cls
   }
-  */
+
 
   // eslint-disable-next-line camelcase
   register_object(...args) {
@@ -56,22 +63,24 @@ class CortexObject {
     const name = String(inputName).toLowerCase()
 
     let singular = singularize(name),
-        plural = pluralize(name)// ,
-        // regName
+        plural = pluralize(name),
+        regName
 
     if (name !== singular && name !== plural) {
       singular = name
       plural = name
     }
-    /*
-    regName = this.registeredAliases[singular] // eslint-disable-line prefer-const
+
+    if (this.registeredAliases) {
+      regName = this.registeredAliases[singular] // eslint-disable-line prefer-const
+    }
 
     if (regName) {
       const obj = this.registeredObjects[regName]
       obj.driver = driver
       return obj
     }
-    */
+
     // Using this allows subclassing of CortexObject
     // eg. HubObject.as('Namespace')
     // eslint-disable-next-line no-new-func
@@ -79,7 +88,7 @@ class CortexObject {
 
     {
       const cls = new CortexObject(singular, driver)
-      // this.register_object(singular, cls, plural)
+      cls.register_object(singular, cls, plural)
       return cls
     }
 

--- a/packages/mdctl-api-driver/lib/cortex.object.js
+++ b/packages/mdctl-api-driver/lib/cortex.object.js
@@ -14,9 +14,9 @@ const { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
         PatchManyOperation,
         BulkOperation
       } = require('./operations'),
-      { QueryCursor, AggregationCursor } = require('./cursor'),
-      registeredObjects = {},
-      registeredAliases = {}
+      { QueryCursor, AggregationCursor } = require('./cursor')
+      // registeredObjects = {},
+      // registeredAliases = {}
 
 class CortexObject {
 
@@ -32,15 +32,17 @@ class CortexObject {
     })
   }
 
-  static registerObject(name, cls, ...aliases) {
+  /*
+  registerObject(name, cls, ...aliases) {
     [name, ...aliases].map(n => n.toLowerCase()).forEach((alias) => {
-      registeredAliases[alias] = name
+      this.registeredAliases[alias] = name
     })
-    registeredObjects[name] = cls
+    this.registeredObjects[name] = cls
   }
+  */
 
   // eslint-disable-next-line camelcase
-  static register_object(...args) {
+  register_object(...args) {
     this.registerObject(...args)
   }
 
@@ -54,22 +56,22 @@ class CortexObject {
     const name = String(inputName).toLowerCase()
 
     let singular = singularize(name),
-        plural = pluralize(name),
-        regName
+        plural = pluralize(name)// ,
+        // regName
 
     if (name !== singular && name !== plural) {
       singular = name
       plural = name
     }
-
-    regName = registeredAliases[singular] // eslint-disable-line prefer-const
+    /*
+    regName = this.registeredAliases[singular] // eslint-disable-line prefer-const
 
     if (regName) {
-      const obj = registeredObjects[regName]
+      const obj = this.registeredObjects[regName]
       obj.driver = driver
       return obj
     }
-
+    */
     // Using this allows subclassing of CortexObject
     // eg. HubObject.as('Namespace')
     // eslint-disable-next-line no-new-func
@@ -77,7 +79,7 @@ class CortexObject {
 
     {
       const cls = new CortexObject(singular, driver)
-      this.register_object(singular, cls, plural)
+      // this.register_object(singular, cls, plural)
       return cls
     }
 
@@ -162,7 +164,8 @@ class Org extends CortexObject {
         if (target[property]) {
           return target[property]
         }
-        target[property] = CortexObject.as(property, driver) // eslint-disable-line no-param-reassign
+        // eslint-disable-next-line no-param-reassign
+        target[property] = CortexObject.as(property, driver)
         return target[property]
       }
     })


### PR DESCRIPTION
When running a study migration in parallel from Axon Deployer, the system throws integrity reference errors, preventing the migration to be completed.

This seems to be due to a caching issue in an MDCTL module (mdctl-api-driver/lib/cortex.ibject.js), that was never spotted before since the snapshots were previously created sequentially.

It is required to move the following global objects that store names and aliases of objects inside CortexObject class:
- registeredObjects
- registeredAliases