### PR TITLE
MIG-126 - ec__builder_data id mappings

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
@@ -1,7 +1,362 @@
 const MenuConfigMap = require('../../lib/mappings/maps/MenuConfigMap')
 const ReviewsTypesMap = require('../../lib/mappings/maps/ReviewTypesMap')
+const EcBuilderDataMap = require('../../lib/mappings/maps/EcBuilderDataMap')
 
-describe('MenuConfigMappings', () => {
+describe('Export Mappings', () => {
+
+  const ecDocTemplate = {
+    "ec__builder_data": {
+      "ck-widgets-data": [
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__initials": false,
+            "ec__key": "c0d68417-3505-45d9-86ee-433e98bd0e2d",
+            "ec__label": "sig",
+            "ec__optional": false,
+            "ec__order": 0,
+            "ec__signer_role": "participant",
+            "ec__title": "sig"
+          },
+          "id": "c0d68417-3505-45d9-86ee-433e98bd0e2d",
+          "type": "signature"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__initials": true,
+            "ec__key": "4f4464f0-ca95-4667-b1c5-1e3cdb0e0e95",
+            "ec__label": "init",
+            "ec__optional": false,
+            "ec__order": 0,
+            "ec__signer_role": "participant",
+            "ec__title": "init"
+          },
+          "id": "4f4464f0-ca95-4667-b1c5-1e3cdb0e0e95",
+          "type": "signature"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "c3064e68-5b30-49ae-8a11-9bb0159d86ad",
+            "ec__optional": false,
+            "ec__signer_role": "participant",
+            "ec__title": "text",
+            "ec__type": "ec__text",
+            "label": "text",
+            "placeholder": null
+          },
+          "id": "c3064e68-5b30-49ae-8a11-9bb0159d86ad",
+          "type": "input"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "eb789d2c-81bf-4288-97b0-2f736624ca14",
+            "ec__optional": false,
+            "ec__signer_role": "participant",
+            "ec__title": "num",
+            "ec__type": "ec__numeric",
+            "label": "num",
+            "placeholder": null
+          },
+          "id": "eb789d2c-81bf-4288-97b0-2f736624ca14",
+          "type": "input"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "574f3e37-4106-47c3-b881-b2a0e6cbceff",
+            "ec__optional": false,
+            "ec__signer_role": "participant",
+            "ec__title": "date",
+            "ec__type": "ec__date",
+            "label": "date",
+            "placeholder": null
+          },
+          "id": "574f3e37-4106-47c3-b881-b2a0e6cbceff",
+          "type": "input"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "19c3ccd3-4a87-4d4e-8368-9481fd1363ba",
+            "ec__optional": false,
+            "ec__signer_role": "participant",
+            "ec__title": "email",
+            "ec__type": "ec__email",
+            "label": "email",
+            "placeholder": null
+          },
+          "id": "19c3ccd3-4a87-4d4e-8368-9481fd1363ba",
+          "type": "input"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "choiceType": "multiple",
+            "ec__allow_multiple": true,
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "fd6435dd-93c0-4221-9cb8-43e61edfc15d",
+            "ec__optional": false,
+            "ec__selection_options": "Choice 1=Choice 1",
+            "ec__signer_role": "participant",
+            "ec__title": "multChoice",
+            "ec__type": "ec__text_choice",
+            "label": "multChoice",
+            "options": [
+              {
+                "name": "Choice 1",
+                "value": "Choice 1"
+              }
+            ]
+          },
+          "id": "fd6435dd-93c0-4221-9cb8-43e61edfc15d",
+          "type": "checkboxGroup"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "choiceType": "single",
+            "ec__allow_multiple": false,
+            "ec__custom_data": [],
+            "ec__description": "",
+            "ec__key": "d230fd0e-f25f-4177-9bb8-238ecf6ae9d3",
+            "ec__optional": false,
+            "ec__selection_options": "Choice 1=Choice 1",
+            "ec__signer_role": "participant",
+            "ec__title": "singChoice",
+            "ec__type": "ec__text_choice",
+            "label": "singChoice",
+            "options": [
+              {
+                "name": "Choice 1",
+                "value": "Choice 1"
+              }
+            ]
+          },
+          "id": "d230fd0e-f25f-4177-9bb8-238ecf6ae9d3",
+          "type": "radioGroup"
+        },
+        {
+          "data": {
+            "_id": "wrongId",
+            "access": 6,
+            "accessRoles": [
+              "62d5e6ce2c84dfd649f1f554"
+            ],
+            "created": "2022-08-31T21:00:36.731Z",
+            "creator": {
+              "_id": "6306a1b610b7f8775736f985",
+              "object": "account",
+              "path": "/accounts/6306a1b610b7f8775736f985"
+            },
+            "doNotPrint": false,
+            "ec__answer_context": " ",
+            "ec__custom_data": [],
+            "ec__description": " ",
+            "ec__document_template": {
+              "_id": "630e6f7228194d6a96fff891",
+              "object": "ec__document_template",
+              "path": "/ec__document_templates/630e6f7228194d6a96fff891"
+            },
+            "ec__identifier": "1661979636011-23",
+            "ec__key": "31c3fa0c-2ab2-48d2-9d97-6f85d76a283b",
+            "ec__label": "knowCheck",
+            "ec__optional": true,
+            "ec__options": [
+              "Choice 1"
+            ],
+            "ec__options_answer": [
+              "Choice 1"
+            ],
+            "ec__question": "knowCheck",
+            "ec__signer_role": "participant",
+            "ec__title": "knowCheck",
+            "ec__type": "ec__knowledge_checks",
+            "favorite": false,
+            "object": "ec__knowledge_check",
+            "owner": {
+              "_id": "6306a1b610b7f8775736f985",
+              "object": "account",
+              "path": "/accounts/6306a1b610b7f8775736f985"
+            },
+            "shared": false
+          },
+          "id": "31c3fa0c-2ab2-48d2-9d97-6f85d76a283b",
+          "type": "knowledgeCheck"
+        }
+      ]
+    },
+    "ec__key": "d86ad548-4b78-4bf7-b115-965160b3f1f9",
+    "ec__knowledge_checks": {
+      "data": [
+        {
+          "_id": "630fcbf41a3f0b3bba09e98d",
+          "access": 7,
+          "accessRoles": [
+            "000000000000000000000004",
+            "000000000000000000000007",
+            "000000000000000000000006"
+          ],
+          "created": "2022-08-31T21:00:36.731Z",
+          "creator": {
+            "_id": "6306a1b610b7f8775736f985",
+            "object": "account",
+            "path": "/accounts/6306a1b610b7f8775736f985"
+          },
+          "ec__answer_context": " ",
+          "ec__description": " ",
+          "ec__document_template": {
+            "_id": "630e6f7228194d6a96fff891",
+            "object": "ec__document_template",
+            "path": "/ec__document_templates/630e6f7228194d6a96fff891"
+          },
+          "ec__identifier": "1661979636011-23",
+          "ec__key": "31c3fa0c-2ab2-48d2-9d97-6f85d76a283b",
+          "ec__label": "knowCheck",
+          "ec__optional": true,
+          "ec__options": [
+            "Choice 1"
+          ],
+          "ec__options_answer": [
+            "Choice 1"
+          ],
+          "ec__question": "knowCheck",
+          "ec__signer_role": "participant",
+          "ec__type": "ec__knowledge_checks",
+          "favorite": false,
+          "object": "ec__knowledge_check",
+          "owner": {
+            "_id": "6306a1b610b7f8775736f985",
+            "object": "account",
+            "path": "/accounts/6306a1b610b7f8775736f985"
+          },
+          "shared": false
+        }
+      ],
+      "hasMore": false,
+      "object": "list",
+      "path": "/ec__document_templates/630e6f7228194d6a96fff891/ec__knowledge_checks"
+    },
+    "ec__requested_data": [
+      {
+        "_id": "630fcb5b1a25d8b04bf939bc",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "c3064e68-5b30-49ae-8a11-9bb0159d86ad",
+        "ec__optional": false,
+        "ec__signer_role": "participant",
+        "ec__title": "text",
+        "ec__type": "ec__text"
+      },
+      {
+        "_id": "630fcb801a25d8b04bf94556",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "eb789d2c-81bf-4288-97b0-2f736624ca14",
+        "ec__optional": false,
+        "ec__signer_role": "participant",
+        "ec__title": "num",
+        "ec__type": "ec__numeric"
+      },
+      {
+        "_id": "630fcb8a1a25d8b04bf94872",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "574f3e37-4106-47c3-b881-b2a0e6cbceff",
+        "ec__optional": false,
+        "ec__signer_role": "participant",
+        "ec__title": "date",
+        "ec__type": "ec__date"
+      },
+      {
+        "_id": "630fcb981a25d8b04bf94c72",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "19c3ccd3-4a87-4d4e-8368-9481fd1363ba",
+        "ec__optional": false,
+        "ec__signer_role": "participant",
+        "ec__title": "email",
+        "ec__type": "ec__email"
+      },
+      {
+        "_id": "630fcbae1a25d8b04bf951c1",
+        "ec__allow_multiple": true,
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "fd6435dd-93c0-4221-9cb8-43e61edfc15d",
+        "ec__optional": false,
+        "ec__selection_options": "Choice 1=Choice 1",
+        "ec__signer_role": "participant",
+        "ec__title": "multChoice",
+        "ec__type": "ec__text_choice"
+      },
+      {
+        "_id": "630fcbc11a25d8b04bf95732",
+        "ec__allow_multiple": false,
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__key": "d230fd0e-f25f-4177-9bb8-238ecf6ae9d3",
+        "ec__optional": false,
+        "ec__selection_options": "Choice 1=Choice 1",
+        "ec__signer_role": "participant",
+        "ec__title": "singChoice",
+        "ec__type": "ec__text_choice"
+      }
+    ],
+    "ec__requested_signatures": [
+      {
+        "_id": "630fcb1b1a25d8b04bf926bd",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__initials": false,
+        "ec__key": "c0d68417-3505-45d9-86ee-433e98bd0e2d",
+        "ec__label": "sig",
+        "ec__optional": false,
+        "ec__order": 0,
+        "ec__signer_role": "participant",
+        "ec__title": "sig"
+      },
+      {
+        "_id": "630fcb451a25d8b04bf932e8",
+        "ec__custom_data": [],
+        "ec__description": "",
+        "ec__initials": true,
+        "ec__key": "4f4464f0-ca95-4667-b1c5-1e3cdb0e0e95",
+        "ec__label": "init",
+        "ec__optional": false,
+        "ec__order": 0,
+        "ec__signer_role": "participant",
+        "ec__title": "init"
+      }
+    ],
+    "ec__signer_roles": [
+      {
+        "_id": "630e6f72ab8436c633714612",
+        "ec__key": "e6af3ceb-56fa-4733-981c-05f20739017c",
+        "ec__order": 1,
+        "ec__role": "participant",
+        "ec__signer_type": "participant"
+      }
+    ],
+    "ec__status": "draft",
+    "ec__title": "template",
+    "object": "ec__document_template"
+  }
 
   const org = {
     objects: {
@@ -129,11 +484,18 @@ describe('MenuConfigMappings', () => {
             }
           }
         }
+      },
+      ec__document_templates: {
+        find: () => ({
+          paths: () => ({
+            toArray: () => ([ecDocTemplate])
+          })
+        })
       }
     }
   }
 
-  it('getMappings', async() => {
+  it('menuConfigMapping', async() => {
     const menuConfigMapping = new MenuConfigMap(org),
           mappings = await menuConfigMapping.getMappings()
 
@@ -268,6 +630,96 @@ describe('MenuConfigMappings', () => {
                 maxTimeMS: 10000,
                 object: 'c_study',
                 operation: 'cursor'
+              }
+            }
+          }
+        ])
+    })
+  }),
+  describe('MIG-126: econsentDocumentTemplateAdjustments', () => {
+    it('getEcBuilderDataMaps', async() => {
+      const mapping = new EcBuilderDataMap(org),
+            mappings = await mapping.getEcBuilderDataMaps()
+
+      expect(mappings)
+        .toStrictEqual([
+          {
+            path: `ec__document_template.d86ad548-4b78-4bf7-b115-965160b3f1f9.ec__builder_data`,
+            mapTo: {
+              "$let": {
+                "vars": {
+                  "originalTemplate": {
+                    "$dbNext": {
+                      "object": "ec__document_template",
+                      "operation": "cursor",
+                      "where": {
+                        "ec__key": "d86ad548-4b78-4bf7-b115-965160b3f1f9"
+                      },
+                      "expand": ["ec__knowledge_checks"],
+                      "passive": true
+                    }
+                  }
+                },
+                "in": {
+                  "$object": {
+                    "ck-widgets-data": {
+                      "$concatArrays": [{
+                        "$map": {
+                          "input": "$$originalTemplate.ec__requested_signatures",
+                          "as": "entry",
+                          "in": {
+                            "$object": {
+                              "data": "$$entry",
+                              "id": "$$entry.ec__key",
+                              "type": {
+                                "$literal": "signature"
+                              }
+                            }
+                          }
+                        }
+                      }, {
+                        "$map": {
+                          "input": "$$originalTemplate.ec__knowledge_checks.data",
+                          "as": "entry",
+                          "in": {
+                            "$object": {
+                              "data": "$$entry",
+                              "id": "$$entry.ec__key",
+                              "type": {
+                                "$literal": "knowledgeCheck"
+                              }
+                            }
+                          }
+                        }
+                      }, {
+                        "$map": {
+                          "input": "$$originalTemplate.ec__requested_data",
+                          "as": "entry",
+                          "in": {
+                            "$object": {
+                              "data": "$$entry",
+                              "id": "$$entry.ec__key",
+                              "type": {
+                                "$cond": [
+                                  "$$entry.ec__allow_multiple", {
+                                    "$literal": "checkboxGroup"
+                                  }, {
+                                    "$cond": [{
+                                      "$eq": ["$$entry.ec__allow_multiple", false]
+                                    }, {
+                                      "$literal": "radioGroup"
+                                    }, {
+                                      "$literal": "input"
+                                    }]
+                                  }]
+                              }
+                            }
+                          }
+                        }
+                      }]
+                    }
+                  }
+                }
               }
             }
           }

--- a/packages/mdctl-axon-tools/lib/mappings/index.js
+++ b/packages/mdctl-axon-tools/lib/mappings/index.js
@@ -18,9 +18,11 @@ mappings.forEach(({ path, mapTo }) => {
       isDocPropUpdate = !!rest.length,
       value = run(mapTo)
 
+  const prop = entity.startsWith('ec__') ? 'ec__key' : 'c_key'
+
   if (isDocPropUpdate) {
     const [entityResult] = org.objects[entity]
-      .find({ c_key: entityKey })
+      .find({ [prop]: entityKey })
       .paths(property)
       .limit(1)
       .toArray()
@@ -47,7 +49,7 @@ mappings.forEach(({ path, mapTo }) => {
 
   //normal prop update
   return org.objects[entity]
-    .updateOne({ c_key: entityKey }, { $set: { [property]: value }})
+    .updateOne({ [prop]: entityKey }, { $set: { [property]: value }})
     .execute()
 
 })`

--- a/packages/mdctl-axon-tools/lib/mappings/maps/EcBuilderDataMap.js
+++ b/packages/mdctl-axon-tools/lib/mappings/maps/EcBuilderDataMap.js
@@ -1,0 +1,117 @@
+/* eslint-disable one-var */
+module.exports = class EcBuilderDataMap {
+
+  constructor(org) {
+    this.org = org
+  }
+
+  async getEcBuilderDataMaps() {
+
+    const mapping = []
+
+    let ecTemplates = await this.org.objects.ec__document_templates
+      .find({ ec__status: 'draft' })
+      .paths('ec__key', 'ec__builder_data', 'ec__requested_data', 'ec__requested_signatures', 'ec__knowledge_checks')
+      .toArray()
+
+    ecTemplates = ecTemplates.filter(template => template.ec__builder_data && !!template.ec__builder_data['ck-widgets-data'].length)
+
+    for (const template of ecTemplates) {
+      const builderDataKeys = template.ec__builder_data['ck-widgets-data']
+        .map(datum => datum.data.ec__key)
+        .filter(key => !!key)
+
+      if (!builderDataKeys.length) continue
+
+      mapping.push({
+        path: `ec__document_template.${template.ec__key}.ec__builder_data`,
+        mapTo: {
+          "$let": {
+            "vars": {
+              "originalTemplate": {
+                "$dbNext": {
+                  "object": "ec__document_template",
+                  "operation": "cursor",
+                  "where": {
+                    "ec__key": template.ec__key
+                  },
+                  "expand": ["ec__knowledge_checks"],
+                  "passive": true
+                }
+              }
+            },
+            "in": {
+              "$object": {
+                "ck-widgets-data": {
+                  "$concatArrays": [{
+                    "$map": {
+                      "input": "$$originalTemplate.ec__requested_signatures",
+                      "as": "entry",
+                      "in": {
+                        "$object": {
+                          "data": "$$entry",
+                          "id": "$$entry.ec__key",
+                          "type": {
+                            "$literal": "signature"
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "$map": {
+                      "input": "$$originalTemplate.ec__knowledge_checks.data",
+                      "as": "entry",
+                      "in": {
+                        "$object": {
+                          "data": "$$entry",
+                          "id": "$$entry.ec__key",
+                          "type": {
+                            "$literal": "knowledgeCheck"
+                          }
+                        }
+                      }
+                    }
+                  }, {
+                    "$map": {
+                      "input": "$$originalTemplate.ec__requested_data",
+                      "as": "entry",
+                      "in": {
+                        "$object": {
+                          "data": "$$entry",
+                          "id": "$$entry.ec__key",
+                          "type": {
+                            "$cond": [
+                              "$$entry.ec__allow_multiple", {
+                                "$literal": "checkboxGroup"
+                              }, {
+                                "$cond": [{
+                                  "$eq": ["$$entry.ec__allow_multiple", false]
+                                }, {
+                                  "$literal": "radioGroup"
+                                }, {
+                                  "$literal": "input"
+                                }]
+                              }]
+                          }
+                        }
+                      }
+                    }
+                  }]
+                }
+              }
+            }
+          }
+        }
+      })
+    }
+    return mapping
+  }
+
+  async getMappings() {
+    return [
+      ...await this.getEcBuilderDataMaps()
+    ]
+  }
+
+
+}

--- a/packages/mdctl-axon-tools/lib/mappings/maps/index.js
+++ b/packages/mdctl-axon-tools/lib/mappings/maps/index.js
@@ -1,14 +1,17 @@
 const MenuConfigMap = require('./MenuConfigMap')
 const ReviewsTypesMap = require('./ReviewTypesMap')
+const EcBuilderDataMap = require('./EcBuilderDataMap')
 
 module.exports = {
   async getMappings(org) {
     const menuConfigMap = new MenuConfigMap(org),
-          reviewsTypesMap = new ReviewsTypesMap(org)
+          reviewsTypesMap = new ReviewsTypesMap(org),
+          ecBuilderDataMap = new EcBuilderDataMap(org)
 
     return [
       ...await menuConfigMap.getMappings(),
-      ...await reviewsTypesMap.getMappings()
+      ...await reviewsTypesMap.getMappings(),
+      ...await ecBuilderDataMap.getMappings()
     ]
   }
 }


### PR DESCRIPTION
ec__document_template.ec__builder_data contains strings that include _id's in them, which did not get updated during migration, even though the _id's change as a result of migration. This mapping updates those strings to reference the new _id's