### PR TITLE
Added support for multiple locales per template file

### DIFF
--- a/packages/mdctl-core/streams/section.js
+++ b/packages/mdctl-core/streams/section.js
@@ -3,7 +3,6 @@ const _ = require('lodash'),
       mime = require('mime'),
       uuid = require('uuid'),
       pluralize = require('pluralize'),
-      { hashCode } = require('@medable/mdctl-node-utils/crypto'),
       { isCustomName, isInteger } = require('@medable/mdctl-core-utils/values'),
       ENV_KEYS = {
         keys: ['app', 'config', 'notification', 'policy', 'role', 'smsNumber', 'serviceAccount', 'storageLocation', 'configuration', 'template', 'object', 'script', 'view', 'i18n'],
@@ -39,7 +38,8 @@ const _ = require('lodash'),
       },
       NON_WRITABLE_KEYS = ['facet'],
       SectionsCreated = [],
-      { privatesAccessor } = require('@medable/mdctl-core-utils/privates')
+      { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
+      hash = require('crypto').createHash('md5')
 
 class ExportSection {
 
@@ -284,11 +284,9 @@ class ExportSection {
               objectPath.push('data')
               if (cnt.data) {
                 let localeInName;
-
                 if (_.isArray(l.locale)){
-
                   if(l.locale.length > 1) {
-                    localeInName = hashCode(l.locale.join())
+                    localeInName = hash.update(l.locale.join()).digest('hex')
                   } else {
                     if (_.isEqual(l.locale, ['*'])) {
                       localeInName = 'anyLocale'

--- a/packages/mdctl-core/streams/section.js
+++ b/packages/mdctl-core/streams/section.js
@@ -3,6 +3,7 @@ const _ = require('lodash'),
       mime = require('mime'),
       uuid = require('uuid'),
       pluralize = require('pluralize'),
+      { hashCode } = require('@medable/mdctl-node-utils/crypto'),
       { isCustomName, isInteger } = require('@medable/mdctl-core-utils/values'),
       ENV_KEYS = {
         keys: ['app', 'config', 'notification', 'policy', 'role', 'smsNumber', 'serviceAccount', 'storageLocation', 'configuration', 'template', 'object', 'script', 'view', 'i18n'],
@@ -282,8 +283,25 @@ class ExportSection {
               objectPath.push(i)
               objectPath.push('data')
               if (cnt.data) {
+                let localeInName;
+
+                if (_.isArray(l.locale)){
+
+                  if(l.locale.length > 1) {
+                    localeInName = hashCode(l.locale.join())
+                  } else {
+                    if (_.isEqual(l.locale, ['*'])) {
+                      localeInName = 'anyLocale'
+                    } else {
+                      localeInName = l.locale[0]
+                    }
+                  }
+                } else {
+                  localeInName = l.locale
+                }
+                
                 privatesAccessor(this).templateFiles.push({
-                  name: `${name}.${l.locale}.${cnt.name}`,
+                  name: `${name}.${localeInName}.${cnt.name}`,
                   ext: TEMPLATES_EXT[content.type][cnt.name],
                   data: cnt.data,
                   remoteLocation: false,

--- a/packages/mdctl-core/test/section_template_test.js
+++ b/packages/mdctl-core/test/section_template_test.js
@@ -1,0 +1,96 @@
+let {ExportSection} = require('../streams/section')
+let { assert } = require('chai')
+
+describe('Section templates export', () => {
+    it('should export template file with locale name if locale is array length 1', () => {
+        let section = new ExportSection({
+            type: 'email', 
+            name: 'html', 
+            object: 'template',
+            localizations: [
+                {
+                    locale: ['en_US'], 
+                    content: [
+                        {
+                          "data": "Content in en_US language",
+                          "name": "html"
+                        }
+                      ]
+                }
+            ]
+        }, 'template')
+
+        section.extractTemplates()
+        assert(section.templateFiles.length === 1)
+        assert(section.templateFiles[0].name === 'template.email.html.en_US.html')
+    })
+
+    it('should export template file with name if locale is string', () => {
+        let section = new ExportSection({
+            type: 'email', 
+            name: 'html', 
+            object: 'template',
+            localizations: [
+                {
+                    locale: 'en_US', 
+                    content: [
+                        {
+                          "data": "Content in en_US language",
+                          "name": "html"
+                        }
+                      ]
+                }
+            ]
+        }, 'template')
+
+        section.extractTemplates()
+        assert(section.templateFiles.length === 1)
+        assert(section.templateFiles[0].name === 'template.email.html.en_US.html')
+    })
+
+    it('should export template file with name hashed if locale is an array with multiple locales', () => {
+        let section = new ExportSection({
+            type: 'email', 
+            name: 'html', 
+            object: 'template',
+            localizations: [
+                {
+                    locale: ['en_US', 'en_UK'], 
+                    content: [
+                        {
+                          "data": "Content in multiple languages",
+                          "name": "html"
+                        }
+                      ]
+                }
+            ]
+        }, 'template')
+
+        section.extractTemplates()
+        assert(section.templateFiles.length === 1)
+        assert(section.templateFiles[0].name === 'template.email.html.a60ac79e553bf2d10265482effc688c2.html')
+    })
+
+    it('should export template file with name anyLocale if locale is ["*"]', () => {
+        let section = new ExportSection({
+            type: 'email', 
+            name: 'html', 
+            object: 'template',
+            localizations: [
+                {
+                    locale: ['*'], 
+                    content: [
+                        {
+                          "data": "Content in multiple languages",
+                          "name": "html"
+                        }
+                      ]
+                }
+            ]
+        }, 'template')
+
+        section.extractTemplates()
+        assert(section.templateFiles.length === 1)
+        assert(section.templateFiles[0].name === 'template.email.html.anyLocale.html')
+    })
+})

--- a/packages/mdctl-node-utils/crypto.js
+++ b/packages/mdctl-node-utils/crypto.js
@@ -22,6 +22,20 @@ function md5FileHash(filename) {
   return hash.digest('hex')
 }
 
+function hashCode(str, seed = 0) {
+  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+  for (let i = 0, ch; i < str.length; i++) {
+    ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+};
+
+
 module.exports = {
-  md5FileHash
+  md5FileHash, 
+  hashCode
 }

--- a/packages/mdctl-node-utils/crypto.js
+++ b/packages/mdctl-node-utils/crypto.js
@@ -22,20 +22,6 @@ function md5FileHash(filename) {
   return hash.digest('hex')
 }
 
-function hashCode(str, seed = 0) {
-  let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
-  for (let i = 0, ch; i < str.length; i++) {
-    ch = str.charCodeAt(i);
-    h1 = Math.imul(h1 ^ ch, 2654435761);
-    h2 = Math.imul(h2 ^ ch, 1597334677);
-  }
-  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-  return 4294967296 * (2097151 & h2) + (h1 >>> 0);
-};
-
-
 module.exports = {
-  md5FileHash, 
-  hashCode
+  md5FileHash
 }


### PR DESCRIPTION
Required by i18n Initiative. 

Multiple locales supported via array per template file. New fn is backward compatible as well for the old style of export. 

If one locale, then template file is named according to that. If multiple, then its a hash of the locales array. Otherwise, if it is * then the template file is named anyLocale. 

Things to consider: 
1. Ordering of the locales array before we hashing, as the hash will change otherwise. 
2. Publishing the node-utils package as we're using a new function added to the crypto library 