### PR TITLE
Added template ID in the select consent templates list when exporting

### DIFF
--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -52,7 +52,7 @@ class StudyManifestTools {
           driver = new Driver(client),
           org = new Org(driver)
 
-    return org.objects.ec__document_templates.find().limit(false).paths('ec__title').toArray()
+    return org.objects.ec__document_templates.find().limit(false).paths('ec__title', 'ec__identifier').toArray()
   }
 
   async getOrgObjectInfo(org) {

--- a/packages/mdctl-cli/lib/studyQuestions.js
+++ b/packages/mdctl-cli/lib/studyQuestions.js
@@ -16,11 +16,11 @@ const { prompt } = require('inquirer'),
 
       askSelectConsentTemplates = async(inputArgs) => {
         // eslint-disable-next-line no-underscore-dangle
-        const choices = inputArgs.consents.map(v => ({ name: v.ec__title, value: v._id })),
+        const choices = inputArgs.consents.map(v => ({ name: `${v.ec__identifier} || ${v.ec__title}`, value: v._id })),
               result = await prompt([{
                 type: 'checkbox',
                 name: 'selectedConsents',
-                message: 'Please Select the Tasks you wish to export',
+                message: 'Please Select the Templates you wish to export',
                 choices
               }])
 


### PR DESCRIPTION
Because in most cases the template titles (names) are pretty similar, we have added the template ID so it's easier for the user to pick the template they want to export.
<img width="843" alt="Screen Shot 2022-10-13 at 2 40 22 PM" src="https://user-images.githubusercontent.com/4236289/195576034-31d3ba14-b994-4554-96f9-e00fe304c274.png">
