### PR TITLE
MIG-143: extended partial object list and updated tests

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-85/MIG-85.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-85/MIG-85.test.js
@@ -5,8 +5,7 @@ jest.mock('@medable/mdctl-api-driver/lib/cortex.object', () => ({ Object: class 
 jest.mock('../../lib/mappings')
 
 const fs = require('fs'),
-      StudyManifestTools = require('../../lib/StudyManifestTools'),
-      study = require('../../../mdctl-cli/tasks/study')
+      StudyManifestTools = require('../../lib/StudyManifestTools')
 
 describe('MIG-85 - Test partial migrations in StudyManifestTools', () => {
 
@@ -102,6 +101,13 @@ describe('MIG-85 - Test partial migrations in StudyManifestTools', () => {
               find: () => ({
                 limit: () => ({
                   toArray: () => entities.filter(e => e.object === 'c_task')
+                })
+              })
+            },
+            object: {
+              find: () => ({
+                paths: () => ({
+                  toArray: () => [{ uniqueKey: 'c_key' }]
                 })
               })
             }
@@ -227,6 +233,7 @@ describe('MIG-85 - Test partial migrations in StudyManifestTools', () => {
           ingestTransform = fs.readFileSync(`${__dirname}/../../packageScripts/ingestTransform.js`).toString()
 
     jest.spyOn(StudyManifestTools.prototype, 'getOrgObjectInfo').mockImplementation(() => dummyReferences)
+    jest.spyOn(StudyManifestTools.prototype, 'getOrgAndReferences').mockImplementation(() => ({ org, dummyReferences }))
     jest.spyOn(StudyManifestTools.prototype, 'validateReferences').mockImplementation(() => entities)
     jest.spyOn(StudyManifestTools.prototype, 'createManifest').mockImplementation(() => manifest)
     jest.spyOn(StudyManifestTools.prototype, 'getObjectIDsArray').mockImplementation(() => entities.filter(o => o.object === 'c_task'))


### PR DESCRIPTION
Extended list of exportable objects on partial migrations as per  [MIG-143](https://jira.devops.medable.com/browse/MIG-143). MDCTL now will allow partial migration of the following object instances:

- Study Details
- Anchor Dates
- Participant Schedules
- Participant Flags
- Tasks (already exists)
- Task Assignments
- Sites
- Visit Schedules
- Groups
- Templates (already exists)
- Reports
- Faults
- Looker