### PR TITLE
Remove deprecated stream-to-iter

### DIFF
--- a/packages/mdctl-api-driver/lib/cursor.js
+++ b/packages/mdctl-api-driver/lib/cursor.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-param-reassign, max-len, no-restricted-syntax */
 const { Transform } = require('stream'),
       pump = require('pump'),
-      streamToIterator = require('stream-to-iterator'),
       _ = require('lodash'),
       { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
       {
@@ -36,7 +35,7 @@ class BaseCursor extends Transform {
   }
 
   get iterator() {
-    return streamToIterator(this)
+    return this
   }
 
   stream(options) {

--- a/packages/mdctl-api-driver/package.json
+++ b/packages/mdctl-api-driver/package.json
@@ -32,8 +32,7 @@
     "inflection": "^1.12.0",
     "lodash": "^4.17.21",
     "ndjson": "^1.5.0",
-    "pump": "^3.0.0",
-    "stream-to-iterator": "^3.0.2-0"
+    "pump": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/packages/mdctl-axon-tools/package.json
+++ b/packages/mdctl-axon-tools/package.json
@@ -34,8 +34,7 @@
     "lodash": "^4.17.14",
     "moment": "^2.29.1",
     "ndjson": "^1.5.0",
-    "pump": "^3.0.0",
-    "stream-to-iterator": "^3.0.2-0"
+    "pump": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
`stream-to-iter` functionality has been included since version 10 of node. Removing this dependency will remove bad engine warning during installation:
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'stream-to-iterator@3.0.3',
npm WARN EBADENGINE   required: { node: '>=8.9 <10' },
npm WARN EBADENGINE   current: { node: 'v16.18.1', npm: '8.19.2' }
npm WARN EBADENGINE }
```