### PR TITLE
MIG-156 : added flag to exclude eTemplates from study export

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-154/MIG-154.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-154/MIG-154.test.js
@@ -41,21 +41,24 @@ describe('MIG-154 - Check new methods', () => {
   })
 
   it('Test getKeyName', async() => {
-    const orgObjects = {
-      find: (filter) => {
-        const mockedObjects = [
-          {
-            name: 'c_task',
-            uniqueKey: 'c_key'
-          },
-          {
-            name: 'c_visit',
-            uniqueKey: ''
-          }
-        ]
-        return mockedObjects.filter(e => e.name === filter.name)
+    const orgObjects = [
+      {
+        name: 'c_fault',
+        uniqueKey: 'c_key'
+      },
+      {
+        name: 'c_group',
+        uniqueKey: 'c_key'
+      },
+      {
+        name: 'c_task',
+        uniqueKey: 'c_key'
+      },
+      {
+        name: 'c_visit',
+        uniqueKey: ''
       }
-    }
+    ]
 
     jest.mock('@medable/mdctl-core-utils/privates', () => ({ privatesAccessor: () => ({ orgObjects }) }))
     // eslint-disable-next-line global-require

--- a/packages/mdctl-axon-tools/__tests__/MIG-156/MIG-156.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-156/MIG-156.test.js
@@ -1,0 +1,251 @@
+/* eslint-disable import/order */
+
+jest.mock('@medable/mdctl-api-driver', () => ({ Driver: class {} }), { virtual: true })
+jest.mock('@medable/mdctl-api-driver/lib/cortex.object', () => ({ Object: class {}, Org: class {} }), { virtual: true })
+jest.mock('../../lib/mappings')
+
+const fs = require('fs'),
+      StudyManifestTools = require('../../lib/StudyManifestTools')
+
+describe('MIG-156 - Test eTemplate exclusion in StudyManifestTools', () => {
+
+  let manifestTools
+  const mockGetExportedObjects = jest.fn(() => []),
+        existingStudy = {
+          _id: '1',
+          c_name: 'Study',
+          c_key: 'abc'
+        },
+        hasNextStudyMock = jest.fn(() => true),
+        nextStudyMock = jest.fn(() => existingStudy),
+        entities = [{
+          _id: '615bcd016631cc0100d2766c',
+          object: 'c_study',
+          c_key: 'key-001'
+        },
+        {
+          _id: '615b60d1bf2e4301008f4d68',
+          object: 'c_dummy_object',
+          c_key: 'key-002'
+        },
+        {
+          _id: '619aaaafe44c6e01003f7313',
+          object: 'c_task',
+          c_key: 'key-003'
+        },
+        {
+          _id: '61981246ca9563010037bfa8',
+          object: 'c_task',
+          c_key: 'key-004'
+        },
+        {
+          _id: '61981246ca95714c14e61a8c',
+          object: 'c_step',
+          c_key: 'key-005'
+        },
+        {
+          _id: '61981246ca966caef6108f28',
+          object: 'c_step',
+          c_key: 'key-006'
+        },
+        {
+          _id: '61981246ca9592ee0e41a3dd',
+          object: 'ec__document_template',
+          c_key: 'key-007'
+        },
+        {
+          _id: '61980eb292466ea32e087378',
+          object: 'ec__document_template',
+          c_key: 'key-008'
+        },
+        {
+          _id: '6d525cf2e328e7300d97c399',
+          object: 'ec__default_document_css',
+          c_key: 'key-009'
+        },
+        {
+          _id: '6d525cfe328e64ac0833baef',
+          object: 'ec__knowledge_check',
+          c_key: 'key-010'
+        },
+        {
+          _id: '6d525f2e328e7f1e48262523',
+          object: 'ec__knowledge_check',
+          c_key: 'key-011'
+        },
+        {
+          _id: '6d525gbed28e7f1e4826bb76',
+          object: 'c_visit_schedule',
+          c_key: 'key-012'
+        },
+        {
+          _id: '6d525gc1408e7f1e4826bb11',
+          object: 'c_visit',
+          c_key: 'key-013'
+        },
+        {
+          _id: '6d525gbe28e7fc4ff43c310',
+          object: 'c_group',
+          c_key: 'key-014'
+        },
+        {
+          _id: '67725gbe28e7f98ee3c8667',
+          object: 'c_group_task',
+          c_key: 'key-015'
+        }],
+        dummyReferences = [
+          {
+            name: 'c_study',
+            array: false,
+            object: 'c_study',
+            type: 'Reference',
+            required: false
+          }
+        ],
+        org = {
+          objects: {
+            c_study: {
+              readOne: () => ({
+                execute: () => ({
+                  hasNext: hasNextStudyMock,
+                  next: nextStudyMock
+                })
+              })
+            },
+            c_task: {
+              find: () => ({
+                limit: () => ({
+                  toArray: () => entities.filter(e => e.object === 'c_task')
+                })
+              })
+            },
+            ec__document_template: {
+              find: () => ({
+                limit: () => ({
+                  toArray: () => entities.filter(e => e.object === 'ec__document_template')
+                })
+              })
+            },
+            object: {
+              find: () => ({
+                paths: () => ({
+                  toArray: () => [{ uniqueKey: 'c_key' }]
+                })
+              })
+            }
+          }
+        }
+
+  beforeAll(async() => {
+    manifestTools = new StudyManifestTools({})
+    manifestTools.getExportObjects = mockGetExportedObjects
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('Test eTemplates not excluded from manifest', async() => {
+    const manifestEntitiesToCompare = [
+            {
+              _id: '619aaaafe44c6e01003f7313',
+              object: 'c_task',
+              c_key: 'key-003'
+            },
+            {
+              _id: '61981246ca9563010037bfa8',
+              object: 'c_task',
+              c_key: 'key-004'
+            },
+            {
+              _id: '61981246ca95714c14e61a8c',
+              object: 'c_step',
+              c_key: 'key-005'
+            },
+            {
+              _id: '61981246ca966caef6108f28',
+              object: 'c_step',
+              c_key: 'key-006'
+            },
+            {
+              _id: '61981246ca9592ee0e41a3dd',
+              object: 'ec__document_template',
+              c_key: 'key-007'
+            },
+            {
+              _id: '61980eb292466ea32e087378',
+              object: 'ec__document_template',
+              c_key: 'key-008'
+            },
+            {
+              _id: '6d525cf2e328e7300d97c399',
+              object: 'ec__default_document_css',
+              c_key: 'key-009'
+            },
+            {
+              _id: '6d525cfe328e64ac0833baef',
+              object: 'ec__knowledge_check',
+              c_key: 'key-010'
+            },
+            {
+              _id: '6d525f2e328e7f1e48262523',
+              object: 'ec__knowledge_check',
+              c_key: 'key-011'
+            }
+          ],
+          exportableObject = manifestTools.getAvailableObjectNames(),
+          keyName = 'c_key'
+
+    jest.spyOn(StudyManifestTools.prototype, 'getExportableObjects').mockImplementation(() => exportableObject)
+    jest.spyOn(StudyManifestTools.prototype, 'getKeyName').mockImplementation(key => ((key === 'ec__document_template') ? 'ec__key' : keyName))
+    jest.spyOn(StudyManifestTools.prototype, 'getTaskManifestEntities').mockImplementation(() => entities.filter(o => ['c_task', 'c_step', 'c_branch'].includes(o.object)))
+    jest.spyOn(StudyManifestTools.prototype, 'getConsentManifestEntities').mockImplementation(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
+    jest.spyOn(StudyManifestTools.prototype, 'getObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key))
+    jest.spyOn(StudyManifestTools.prototype, 'mapObjectNameToPlural').mockImplementation(key => `${key}s`)
+    // eslint-disable-next-line one-var, max-len
+    const manifestEntities = await manifestTools.getStudyManifestEntities(org, existingStudy, {}, dummyReferences, false)
+
+    expect(manifestEntities)
+      .toStrictEqual(manifestEntitiesToCompare)
+  })
+
+  it('Test eTemplates excluded from manifest', async() => {
+    const manifestEntitiesToCompare = [
+            {
+              _id: '619aaaafe44c6e01003f7313',
+              object: 'c_task',
+              c_key: 'key-003'
+            },
+            {
+              _id: '61981246ca9563010037bfa8',
+              object: 'c_task',
+              c_key: 'key-004'
+            },
+            {
+              _id: '61981246ca95714c14e61a8c',
+              object: 'c_step',
+              c_key: 'key-005'
+            },
+            {
+              _id: '61981246ca966caef6108f28',
+              object: 'c_step',
+              c_key: 'key-006'
+            }
+          ],
+          exportableObject = manifestTools.getAvailableObjectNames(),
+          keyName = 'c_key'
+
+    jest.spyOn(StudyManifestTools.prototype, 'getExportableObjects').mockImplementation(() => exportableObject)
+    jest.spyOn(StudyManifestTools.prototype, 'getKeyName').mockImplementation(key => ((key === 'ec__document_template') ? 'ec__key' : keyName))
+    jest.spyOn(StudyManifestTools.prototype, 'getTaskManifestEntities').mockImplementation(() => entities.filter(o => ['c_task', 'c_step', 'c_branch'].includes(o.object)))
+    jest.spyOn(StudyManifestTools.prototype, 'getConsentManifestEntities').mockImplementation(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
+    jest.spyOn(StudyManifestTools.prototype, 'getObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key))
+    jest.spyOn(StudyManifestTools.prototype, 'mapObjectNameToPlural').mockImplementation(key => `${key}s`)
+    // eslint-disable-next-line one-var, max-len
+    const manifestEntities = await manifestTools.getStudyManifestEntities(org, existingStudy, {}, dummyReferences, true)
+
+    expect(manifestEntities)
+      .toStrictEqual(manifestEntitiesToCompare)
+  })
+
+})

--- a/packages/mdctl-cli/tasks/study.js
+++ b/packages/mdctl-cli/tasks/study.js
@@ -50,6 +50,10 @@ class Study extends Task {
       preserveTemplateStatus: {
         type: 'boolean',
         default: false
+      },
+      excludeTemplates: {
+        type: 'boolean',
+        default: false
       }
     }
 
@@ -84,14 +88,15 @@ class Study extends Task {
     const client = await cli.getApiClient({ credentials: await cli.getAuthOptions() }),
           params = await cli.getArguments(this.optionKeys),
           studyTools = new StudyManifestTools(client, params),
-          manifestObj = params.manifestObject
+          manifestObj = params.manifestObject,
+          excludeTemplates = !!params.excludeTemplates
 
     try {
       let manifestJSON
       if (manifestObj) {
         manifestJSON = this.validateManifest(manifestObj, studyTools.getAvailableObjectNames())
       }
-      const { manifest } = await studyTools.getStudyManifest(manifestJSON)
+      const { manifest } = await studyTools.getStudyManifest(manifestJSON, excludeTemplates)
 
       if (!params.manifestOnly) {
         const options = {
@@ -104,7 +109,7 @@ class Study extends Task {
       }
 
       console.log('Study Export finished...!')
-
+      return manifest
 
     } catch (e) {
       throw e
@@ -278,7 +283,7 @@ class Study extends Task {
     
     Usage: 
       
-      mdctl study [command] --manifestObject     
+      mdctl study [command]     
           
     Arguments:               
       
@@ -296,6 +301,8 @@ class Study extends Task {
                             can be exported through "mdctl env export" command
 
         --preserveTemplateStatus - If set, keep template status as is while importing
+
+        --excludeTemplates - for study export: exclude eTemplates from manifest and export folder. Default false.  
       
       Notes
         

--- a/packages/mdctl-cli/test/tasks/study.js
+++ b/packages/mdctl-cli/test/tasks/study.js
@@ -1,7 +1,128 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-unused-vars */
 const { assert, expect } = require('chai'),
+      sinon = require('sinon'),
       { StudyManifestTools } = require('@medable/mdctl-axon-tools'),
-      Study = require('../../tasks/study')
+      MdCtlCli = require('../../mdctl'),
+      Study = require('../../tasks/study'),
+      existingStudy = {
+        _id: '1',
+        c_name: 'Study',
+        c_key: 'abc'
+      },
+      entities = [{
+        _id: '615bcd016631cc0100d2766c',
+        object: 'c_study',
+        c_key: 'key-001'
+      },
+      {
+        _id: '619aaaafe44c6e01003f7313',
+        object: 'c_task',
+        c_key: 'key-003'
+      },
+      {
+        _id: '61981246ca9563010037bfa8',
+        object: 'c_task',
+        c_key: 'key-004'
+      },
+      {
+        _id: '61981246ca95714c14e61a8c',
+        object: 'c_step',
+        c_key: 'key-005'
+      },
+      {
+        _id: '61981246ca966caef6108f28',
+        object: 'c_step',
+        c_key: 'key-006'
+      },
+      {
+        _id: '61981246ca9592ee0e41a3dd',
+        object: 'ec__document_template',
+        ec__key: 'key-007'
+      },
+      {
+        _id: '61980eb292466ea32e087378',
+        object: 'ec__document_template',
+        ec__key: 'key-008'
+      },
+      {
+        _id: '6d525cf2e328e7300d97c399',
+        object: 'ec__default_document_css',
+        c_key: 'key-009'
+      },
+      {
+        _id: '6d525cfe328e64ac0833baef',
+        object: 'ec__knowledge_check',
+        c_key: 'key-010'
+      },
+      {
+        _id: '6d525f2e328e7f1e48262523',
+        object: 'ec__knowledge_check',
+        c_key: 'key-011'
+      },
+      {
+        _id: '6d525gbed28e7f1e4826bb76',
+        object: 'c_visit_schedule',
+        c_key: 'key-012'
+      },
+      {
+        _id: '6d525gc1408e7f1e4826bb11',
+        object: 'c_visit',
+        c_key: 'key-013'
+      },
+      {
+        _id: '6d525gbe28e7fc4ff43c310',
+        object: 'c_group',
+        c_key: 'key-014'
+      },
+      {
+        _id: '67725gbe28e7f98ee3c8667',
+        object: 'c_group_task',
+        c_key: 'key-015'
+      }],
+      dummyReferences = [
+        {
+          name: 'c_study',
+          array: false,
+          object: 'c_study',
+          type: 'Reference',
+          required: false
+        }
+      ],
+      org = {
+        objects: {
+          c_study: {
+            readOne: () => ({
+              execute: () => ({
+                hasNext: true,
+                next: existingStudy
+              })
+            })
+          },
+          c_task: {
+            find: () => ({
+              limit: () => ({
+                toArray: () => entities.filter(e => e.object === 'c_task')
+              })
+            })
+          },
+          ec__document_template: {
+            find: () => ({
+              limit: () => ({
+                toArray: () => entities.filter(e => e.object === 'ec__document_template')
+              })
+            })
+          },
+          object: {
+            find: () => ({
+              paths: () => ({
+                toArray: () => [{ uniqueKey: 'c_key' }]
+              })
+            })
+          }
+        }
+      }
+
 
 let study,
     studyManifest
@@ -131,4 +252,120 @@ describe('MIG-85 - Test partial migrations in study.js module', () => {
 
   })
 
+})
+
+describe('MIG-156 - Test eTemplate exclusion flag in study.js module', () => {
+  beforeEach(() => {
+    sinon.stub(MdCtlCli.prototype, 'getAuthOptions').returns({ env: 'local', endpoint: 'https://api.local.medable.com' })
+    sinon.stub(MdCtlCli.prototype, 'getApiClient').returns({})
+    study = new Study()
+    studyManifest = new StudyManifestTools()
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('Test study export include templates', async() => {
+    const manifestEntitiesToCompare = {
+            object: 'manifest',
+            dependencies: false,
+            exportOwner: false,
+            importOwner: false,
+            c_study: {
+              includes: ['key-001'],
+              defer: [
+                'c_public_group',
+                'c_default_subject_site',
+                'c_default_subject_visit_schedule',
+                'c_default_subject_group',
+                'c_default_participant_schedule',
+                'c_menu_config.c_group_id'
+              ]
+            },
+            c_task: { includes: ['key-003', 'key-004'] },
+            c_step: { includes: ['key-005', 'key-006'] },
+            c_visit_schedule: { includes: ['key-012'] },
+            c_visit: { includes: ['key-013'] },
+            c_group: { includes: ['key-014'] },
+            c_group_task: { includes: ['key-015'] }
+          },
+          exportableObject = studyManifest.getAvailableObjectNames(),
+          keyName = 'c_key',
+          cli = new MdCtlCli()
+
+    sinon.stub(MdCtlCli.prototype, 'getArguments').returns(({ excludeTemplates: false, manifestOnly: true }))
+    sinon.stub(StudyManifestTools.prototype, 'getExportableObjects').returns(exportableObject)
+    sinon.stub(StudyManifestTools.prototype, 'getExportObjects').returns([])
+    sinon.stub(StudyManifestTools.prototype, 'getFirstStudy').returns(existingStudy)
+    sinon.stub(StudyManifestTools.prototype, 'getMappings').callsFake(() => '')
+    sinon.stub(StudyManifestTools.prototype, 'getOrgObjectInfo').callsFake(() => dummyReferences)
+    sinon.stub(StudyManifestTools.prototype, 'getKeyName').callsFake(key => ((key === 'ec__document_template') ? 'ec__key' : keyName))
+    sinon.stub(StudyManifestTools.prototype, 'getTaskManifestEntities').callsFake(() => entities.filter(o => ['c_task', 'c_step', 'c_branch'].includes(o.object)))
+    sinon.stub(StudyManifestTools.prototype, 'getConsentManifestEntities').callsFake(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
+    sinon.stub(StudyManifestTools.prototype, 'getObjectIDsArray').callsFake((_org, key, property, values) => entities.filter(o => o.object === key))
+    sinon.stub(StudyManifestTools.prototype, 'validateReferences').callsFake(() => ({ outputEntities: entities.filter(o => !['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)), removedEntities: {} }))
+    sinon.stub(StudyManifestTools.prototype, 'mapObjectNameToPlural').callsFake(key => `${key}s`)
+    sinon.stub(StudyManifestTools.prototype, 'writeToDisk').callsFake(() => {})
+
+    // eslint-disable-next-line one-var
+    const res = await study['study@export'](cli)
+
+    expect(res)
+      .to.deep.equal(manifestEntitiesToCompare)
+
+  })
+
+  it('Test study export exclude eTemplates', async() => {
+    const manifestEntitiesToCompare = {
+            object: 'manifest',
+            dependencies: false,
+            exportOwner: false,
+            importOwner: false,
+            c_study: {
+              includes: ['key-001'],
+              defer: [
+                'c_public_group',
+                'c_default_subject_site',
+                'c_default_subject_visit_schedule',
+                'c_default_subject_group',
+                'c_default_participant_schedule',
+                'c_menu_config.c_group_id'
+              ]
+            },
+            c_task: { includes: ['key-003', 'key-004'] },
+            c_step: { includes: ['key-005', 'key-006'] },
+            ec__document_template: { includes: ['key-007', 'key-008'] },
+            ec__default_document_css: { includes: ['key-009'] },
+            ec__knowledge_check: { includes: ['key-010', 'key-011'] },
+            c_visit_schedule: { includes: ['key-012'] },
+            c_visit: { includes: ['key-013'] },
+            c_group: { includes: ['key-014'] },
+            c_group_task: { includes: ['key-015'] }
+          },
+          exportableObject = studyManifest.getAvailableObjectNames(),
+          keyName = 'c_key',
+          cli = new MdCtlCli()
+
+    sinon.stub(MdCtlCli.prototype, 'getArguments').returns(({ excludeTemplates: true, manifestOnly: true }))
+    sinon.stub(StudyManifestTools.prototype, 'getExportableObjects').returns(exportableObject)
+    sinon.stub(StudyManifestTools.prototype, 'getExportObjects').returns([])
+    sinon.stub(StudyManifestTools.prototype, 'getFirstStudy').returns(existingStudy)
+    sinon.stub(StudyManifestTools.prototype, 'getMappings').callsFake(() => '')
+    sinon.stub(StudyManifestTools.prototype, 'getOrgObjectInfo').callsFake(() => dummyReferences)
+    sinon.stub(StudyManifestTools.prototype, 'getKeyName').callsFake(key => ((key === 'ec__document_template') ? 'ec__key' : keyName))
+    sinon.stub(StudyManifestTools.prototype, 'getTaskManifestEntities').callsFake(() => entities.filter(o => ['c_task', 'c_step', 'c_branch'].includes(o.object)))
+    sinon.stub(StudyManifestTools.prototype, 'getConsentManifestEntities').callsFake(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
+    sinon.stub(StudyManifestTools.prototype, 'getObjectIDsArray').callsFake((_org, key, property, values) => entities.filter(o => o.object === key))
+    sinon.stub(StudyManifestTools.prototype, 'validateReferences').callsFake(() => ({ outputEntities: entities, removedEntities: {} }))
+    sinon.stub(StudyManifestTools.prototype, 'mapObjectNameToPlural').callsFake(key => `${key}s`)
+    sinon.stub(StudyManifestTools.prototype, 'writeToDisk').callsFake(() => {})
+
+    // eslint-disable-next-line one-var
+    const res = await study['study@export'](cli)
+
+    expect(res)
+      .to.deep.equal(manifestEntitiesToCompare)
+
+  })
 })


### PR DESCRIPTION
Created a new flag, called excludeTemplates: when set to "true", eTemplates will not be exported as part of a study export. Default value is false.

Requirement: [MIG-156](https://jira.devops.medable.com/browse/MIG-156)
TDD: [MIG-1.4.0](https://docs.google.com/document/d/1w6ITrDqx8IuJ7beHi6nG4Ih2lu5NF6AiSkZre_bl9LI/edit#)