### PR TITLE
Basic typescript support

### DIFF
--- a/packages/mdctl-api/index.d.ts
+++ b/packages/mdctl-api/index.d.ts
@@ -1,0 +1,40 @@
+export class Environment {
+
+  constructor(input: string)
+  url: string
+
+}
+
+export class Client {
+
+  environment: Environment
+
+  constructor(params: {
+    environment:
+      | {
+      endpoint: string
+      env: string
+    }
+      | string
+    credentials: {
+      type?: string
+      token?: string
+      apiKey?: string
+    }
+    sessions: boolean
+    requestOptions: {
+      strictSSL: boolean
+    }
+  })
+
+  put<R = unknown, P = unknown>(url: string, params: P): Promise<R>
+  delete<R = unknown>(url: string): Promise<R>
+  post<R = unknown, P = unknown, P2 = unknown>(
+    url: string,
+    params: P,
+    param?: P2
+  ): Promise<R>
+
+  get<R = unknown, P = unknown>(url: string, params?: P): Promise<R>
+
+}

--- a/packages/mdctl-api/package.json
+++ b/packages/mdctl-api/package.json
@@ -2,6 +2,7 @@
   "name": "@medable/mdctl-api",
   "version": "1.0.68",
   "description": "Medable Developer Client Tools :: API",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Medable/mdctl.git"

--- a/packages/mdctl-axon-tools/index.d.ts
+++ b/packages/mdctl-axon-tools/index.d.ts
@@ -1,0 +1,13 @@
+import { Client } from '../mdctl-api'
+
+export class StudyManifestTools {
+
+    constructor(client: Client, options: Object)
+    getStudyManifest(manifest?: string): Promise<{
+        manifest: unknown
+        removedEntities: unknown
+        mappingScript: unknown
+        ingestTransform: string
+    }>
+
+}

--- a/packages/mdctl-axon-tools/package.json
+++ b/packages/mdctl-axon-tools/package.json
@@ -2,6 +2,7 @@
   "name": "@medable/mdctl-axon-tools",
   "version": "1.0.68",
   "description": "Medable Axon Tools :: Tools For interaction with Axon orgs",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Medable/mdctl.git"

--- a/packages/mdctl-core-utils/index.d.ts
+++ b/packages/mdctl-core-utils/index.d.ts
@@ -1,0 +1,1 @@
+export * from './values'

--- a/packages/mdctl-core-utils/package.json
+++ b/packages/mdctl-core-utils/package.json
@@ -2,6 +2,7 @@
   "name": "@medable/mdctl-core-utils",
   "version": "1.0.68",
   "description": "Medable Developer Client Tools :: Utils",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Medable/mdctl.git"

--- a/packages/mdctl-core-utils/values.d.ts
+++ b/packages/mdctl-core-utils/values.d.ts
@@ -1,0 +1,5 @@
+export function pathTo(
+  object: object,
+  propertyPath: string,
+  value: unknown
+): object

--- a/packages/mdctl-core/index.d.ts
+++ b/packages/mdctl-core/index.d.ts
@@ -1,0 +1,44 @@
+export class Config {
+
+  constructor()
+  static get global(): Config
+  get credentials(): unknown
+  get client(): {
+    environment:
+      | {
+      endpoint: string
+      env: string
+    }
+      | string
+    credentials: {
+      type: string
+      token: string
+    }
+    sessions: boolean
+    requestOptions: {
+      strictSSL: boolean
+    }
+  }
+
+  get environment(): unknown
+
+}
+
+export class Fault extends Error {
+
+  errCode: string
+  code: string
+  statusCode: number
+  name: string
+  reason: unknown
+  path: string
+  resource: string
+  trace: unknown
+  index: unknown
+  message: string
+
+  static from(err: unknown, forceError?: boolean): Fault | null
+
+  static create(code: string, message: string, statusCode: number): Fault
+
+}

--- a/packages/mdctl-core/package.json
+++ b/packages/mdctl-core/package.json
@@ -2,6 +2,7 @@
   "name": "@medable/mdctl-core",
   "version": "1.0.68",
   "description": "Medable Developer Client Tools :: Core",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Medable/mdctl.git"

--- a/packages/mdctl-export-adapter-tree/index.d.ts
+++ b/packages/mdctl-export-adapter-tree/index.d.ts
@@ -1,0 +1,4 @@
+
+declare class ExportFileTreeAdapter {}
+
+export = ExportFileTreeAdapter

--- a/packages/mdctl-export-adapter-tree/package.json
+++ b/packages/mdctl-export-adapter-tree/package.json
@@ -2,6 +2,7 @@
   "name": "@medable/mdctl-export-adapter-tree",
   "version": "1.0.68",
   "description": "Medable Developer Client Tools :: Export Tree Adapter",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Medable/mdctl.git"


### PR DESCRIPTION
Created Declaration Files (d.ts) files for typescript support when mdctl is used with typescript libraries.
It doesn't contain all typings and needs to be expanded with additional declaration and return types, but it's a good starting point. 
Jira Ticket: [WOLF-123](https://jira.devops.medable.com/browse/WOLF-123)
Impact: This pull request adds Declaration Files, and there is no change in functionality