### PR TITLE
PDT-769 Add mdctl study data-transfer to export dt details

### DIFF
--- a/packages/mdctl-cli/lib/studyQuestions.js
+++ b/packages/mdctl-cli/lib/studyQuestions.js
@@ -1,5 +1,4 @@
 const { prompt } = require('inquirer'),
-      _ = require('lodash'),
 
       askSelectTasks = async(inputArgs) => {
         // eslint-disable-next-line no-underscore-dangle
@@ -25,9 +24,23 @@ const { prompt } = require('inquirer'),
               }])
 
         return result.selectedConsents
+      },
+
+      askSelectDtConfigs = async(dtConfigs) => {
+        // eslint-disable-next-line no-underscore-dangle
+        const choices = dtConfigs.map(v => ({ name: v.dt__name, value: v._id })),
+              result = await prompt([{
+                type: 'checkbox',
+                name: 'selectedDtConfigs',
+                message: 'Please Select the Configs you wish to export',
+                choices
+              }])
+
+        return result.selectedDtConfigs
       }
 
 module.exports = {
   askSelectTasks,
-  askSelectConsentTemplates
+  askSelectConsentTemplates,
+  askSelectDtConfigs
 }

--- a/packages/mdctl-cli/tasks/study.js
+++ b/packages/mdctl-cli/tasks/study.js
@@ -319,6 +319,7 @@ class Study extends Task {
         import - Imports the study into the current org
         task [action] - Allows the select of tasks to export from the current org
         consent [action] - Allows the select of consent templates to export from the current org
+        data-transfer - Allows the select of data transfer configs to export from the current org
 
       Options
 


### PR DESCRIPTION
Adds `mdctl study data-transfer` to export all data transfer related object (dt__config, dt__export, dt__execution). To import to new organization the already existing `mdctl study import` could be used.
