### PR TITLE
MIG-171 - Fixed ECBuilderMap and script

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-148/MIG-148.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-148/MIG-148.test.js
@@ -199,7 +199,7 @@ describe('MIG-148 - Test StudyManifestTools ', () => {
                 paths: () => ({
                   limit: () => ({
                     toArray: () => existingStudy
-                  })
+                  }),
                 })
               })
             },
@@ -265,12 +265,13 @@ describe('MIG-148 - Test StudyManifestTools ', () => {
       if (entity === 'ec__document_template' && prop === 'ec__key' && property === 'ec__builder_data') {
 
         const idMapping = _.keyBy(value['ck-widgets-data'], 'ec__key')
-        const { 
-          ec__builder_data: { "ck-widgets-data": originalBuilderData }, 
-          ec__status 
+        const {
+          _id: template_id,
+          ec__builder_data: { "ck-widgets-data": originalBuilderData },
+          ec__status, creator, owner, updater
         } = org.objects.ec__document_templates.find({ ec__key: entityKey })
-               .paths('ec__builder_data', 'ec__status')
-               .next()
+              .paths('ec__builder_data', 'ec__status', 'creator', 'owner', 'updater')
+              .next()
 
         //We can update only draft templates
         if (ec__status !== 'draft') {
@@ -279,8 +280,13 @@ describe('MIG-148 - Test StudyManifestTools ', () => {
 
         //Map ids between builder_data and corresponding entities
         let new_builder_data = originalBuilderData.map((obd) => {
-            const updatedId = _.get(idMapping, obd.id +'._id')
+            const updatedId = _.get(idMapping, obd.id + '._id')
             _.set(obd, 'data._id', updatedId)
+            _.get(obd, 'data.ec__document_template._id', false) && _.set(obd, 'data.ec__document_template._id', template_id)
+            _.get(obd, 'data.ec__document_template.path', false) && _.set(obd, 'data.ec__document_template.path', '/ec__document_templates/' + template_id)
+            _.get(obd, 'data.creator', false) && _.set(obd, 'data.creator', creator)
+            _.get(obd, 'data.owner', false) && _.set(obd, 'data.owner', owner)
+            _.get(obd, 'data.updater', false) && _.set(obd, 'data.updater', updater)
             return obd
         })
         value = { "ck-widgets-data": new_builder_data }

--- a/packages/mdctl-axon-tools/__tests__/MIG-154/MIG-154.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-154/MIG-154.test.js
@@ -1,4 +1,9 @@
+
 describe('MIG-154 - Check new methods', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
 
   beforeEach(() => {
     /*

--- a/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
@@ -483,8 +483,10 @@ const MenuConfigMap = require('../../lib/mappings/maps/MenuConfigMap'),
           },
           ec__document_templates: {
             find: () => ({
-              paths: () => ({
-                toArray: () => ([ecDocTemplate])
+              limit: () => ({
+                paths: () => ({
+                  toArray: () => ([ecDocTemplate])
+                })
               })
             })
           }
@@ -670,11 +672,8 @@ describe('MIG-126: econsentDocumentTemplateAdjustments', () => {
                         as: 'entry',
                         in: {
                           $object: {
-                            data: '$$entry',
-                            id: '$$entry.ec__key',
-                            type: {
-                              $literal: 'signature'
-                            }
+                            _id: '$$entry._id',
+                            ec__key: '$$entry.ec__key'
                           }
                         }
                       }
@@ -684,11 +683,8 @@ describe('MIG-126: econsentDocumentTemplateAdjustments', () => {
                         as: 'entry',
                         in: {
                           $object: {
-                            data: '$$entry',
-                            id: '$$entry.ec__key',
-                            type: {
-                              $literal: 'knowledgeCheck'
-                            }
+                            _id: '$$entry._id',
+                            ec__key: '$$entry.ec__key'
                           }
                         }
                       }
@@ -698,22 +694,8 @@ describe('MIG-126: econsentDocumentTemplateAdjustments', () => {
                         as: 'entry',
                         in: {
                           $object: {
-                            data: '$$entry',
-                            id: '$$entry.ec__key',
-                            type: {
-                              $cond: [
-                                '$$entry.ec__allow_multiple', {
-                                  $literal: 'checkboxGroup'
-                                }, {
-                                  $cond: [{
-                                    $eq: ['$$entry.ec__allow_multiple', false]
-                                  }, {
-                                    $literal: 'radioGroup'
-                                  }, {
-                                    $literal: 'input'
-                                  }]
-                                }]
-                            }
+                            _id: '$$entry._id',
+                            ec__key: '$$entry.ec__key'
                           }
                         }
                       }

--- a/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-63/MIG-63.test.js
@@ -495,6 +495,10 @@ const MenuConfigMap = require('../../lib/mappings/maps/MenuConfigMap'),
 
 describe('Export Mappings', () => {
 
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it('menuConfigMapping', async() => {
     const menuConfigMapping = new MenuConfigMap(org),
           mappings = await menuConfigMapping.getMappings()

--- a/packages/mdctl-axon-tools/__tests__/TOOLS-42/TOOLS-42.test.js
+++ b/packages/mdctl-axon-tools/__tests__/TOOLS-42/TOOLS-42.test.js
@@ -218,7 +218,7 @@ describe('StudyManifestTools', () => {
     [
       'consent',
       {
-        object: 'package', name: 'Consent export', version: '0.0.1', description: 'An export of task or multiple consent templates', pipes: { ingest: 'ingestTransform.js' }
+        object: 'package', name: 'Consent export', version: '0.0.1', description: 'An export of consent template or multiple consent templates', pipes: { ingest: 'ingestTransform.js' }
       }
     ],
   ])('should writePackage for: %s', (packageType, expected) => {

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -298,7 +298,7 @@ class StudyManifestTools {
 
   async buildConsentManifestAndDependencies(consentIds) {
     const { org, orgReferenceProps } = await this.getOrgAndReferences(),
-          mappingScript = await getEcMappingScript(org),
+          mappingScript = await getEcMappingScript(org, consentIds),
           allEntities = await this.getConsentManifestEntities(org, consentIds, orgReferenceProps),
           { manifest, removedEntities } = this.validateAndCreateManifest(allEntities, orgReferenceProps, ['ec__document_templates'])
 
@@ -928,3 +928,4 @@ class StudyManifestTools {
 }
 
 module.exports = StudyManifestTools
+

--- a/packages/mdctl-axon-tools/lib/mappings/index.js
+++ b/packages/mdctl-axon-tools/lib/mappings/index.js
@@ -2,6 +2,7 @@ const { getMappings, getEcMappings } = require('./maps')
 
 function getScript(mappings) {
   return `
+    import _ from 'lodash'
     const { run } = require('expressions')
 
     const mappings = ${JSON.stringify(mappings)}
@@ -9,8 +10,8 @@ function getScript(mappings) {
     mappings.forEach(({ path, mapTo }) => {
 
       const [entity, entityKey, property, ...rest] = path.split('.'),
-          isDocPropUpdate = !!rest.length,
-          value = run(mapTo)
+          isDocPropUpdate = !!rest.length
+      let value = run(mapTo)
 
       const prop = entity.startsWith('ec__') ? 'ec__key' : 'c_key'
 
@@ -41,6 +42,30 @@ function getScript(mappings) {
 
       }
 
+      if (entity === 'ec__document_template' && prop === 'ec__key' && property === 'ec__builder_data') {
+
+        const idMapping = _.keyBy(value['ck-widgets-data'], 'ec__key')
+        const { 
+          ec__builder_data: { "ck-widgets-data": originalBuilderData }, 
+          ec__status 
+        } = org.objects.ec__document_templates.find({ ec__key: entityKey })
+               .paths('ec__builder_data', 'ec__status')
+               .next()
+
+        //We can update only draft templates
+        if (ec__status !== 'draft') {
+          return
+        }
+
+        //Map ids between builder_data and corresponding entities
+        let new_builder_data = originalBuilderData.map((obd) => {
+            const updatedId = _.get(idMapping, obd.id +'._id')
+            _.set(obd, 'data._id', updatedId)
+            return obd
+        })
+        value = { "ck-widgets-data": new_builder_data }
+      }
+
       //normal prop update
       return org.objects[entity]
         .updateOne({ [prop]: entityKey }, { $set: { [property]: value }})
@@ -59,9 +84,9 @@ module.exports = {
     return getScript(mappings)
   },
 
-  async getEcMappingScript(org) {
+  async getEcMappingScript(org, consentIds = []) {
 
-    const mappings = await getEcMappings(org)
+    const mappings = await getEcMappings(org, consentIds)
 
     if (mappings.length === 0) return ''
 

--- a/packages/mdctl-axon-tools/lib/mappings/index.js
+++ b/packages/mdctl-axon-tools/lib/mappings/index.js
@@ -45,12 +45,13 @@ function getScript(mappings) {
       if (entity === 'ec__document_template' && prop === 'ec__key' && property === 'ec__builder_data') {
 
         const idMapping = _.keyBy(value['ck-widgets-data'], 'ec__key')
-        const { 
-          ec__builder_data: { "ck-widgets-data": originalBuilderData }, 
-          ec__status 
+        const {
+          _id: template_id,
+          ec__builder_data: { "ck-widgets-data": originalBuilderData },
+          ec__status, creator, owner, updater
         } = org.objects.ec__document_templates.find({ ec__key: entityKey })
-               .paths('ec__builder_data', 'ec__status')
-               .next()
+              .paths('ec__builder_data', 'ec__status', 'creator', 'owner', 'updater')
+              .next()
 
         //We can update only draft templates
         if (ec__status !== 'draft') {
@@ -59,8 +60,13 @@ function getScript(mappings) {
 
         //Map ids between builder_data and corresponding entities
         let new_builder_data = originalBuilderData.map((obd) => {
-            const updatedId = _.get(idMapping, obd.id +'._id')
+            const updatedId = _.get(idMapping, obd.id + '._id')
             _.set(obd, 'data._id', updatedId)
+            _.get(obd, 'data.ec__document_template._id', false) && _.set(obd, 'data.ec__document_template._id', template_id)
+            _.get(obd, 'data.ec__document_template.path', false) && _.set(obd, 'data.ec__document_template.path', '/ec__document_templates/' + template_id)
+            _.get(obd, 'data.creator', false) && _.set(obd, 'data.creator', creator)
+            _.get(obd, 'data.owner', false) && _.set(obd, 'data.owner', owner)
+            _.get(obd, 'data.updater', false) && _.set(obd, 'data.updater', updater)
             return obd
         })
         value = { "ck-widgets-data": new_builder_data }

--- a/packages/mdctl-axon-tools/lib/mappings/maps/index.js
+++ b/packages/mdctl-axon-tools/lib/mappings/maps/index.js
@@ -15,11 +15,11 @@ module.exports = {
     ]
   },
 
-  async getEcMappings(org) {
+  async getEcMappings(org, consentIds = []) {
     const ecBuilderDataMap = new EcBuilderDataMap(org)
 
     return [
-      ...await ecBuilderDataMap.getMappings()
+      ...await ecBuilderDataMap.getMappings(consentIds)
     ]
   }
 }


### PR DESCRIPTION
Fixed ECBuilderMap and script to update only ids in ec_builder_data and export only draft templates in the target org

**Changes in export:**

- Fixed the Ec builder data map to contain only ids and `ec_keys`
- Export Builder data maps for affected templates only(those being exported)
- Export Builder data maps for published templates as well, if they are being exported

**Changes in import:** 

- Update only the ids of the `ec__builder_data` in target org
- Update template in the target org only if they are in draft status

**Common:**
- Fixed tests