### PR TITLE
DCT-353 mdctl update to support workflows export/import

### DIFF
--- a/packages/mdctl-axon-tools/__tests__/MIG-156/MIG-156.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-156/MIG-156.test.js
@@ -202,6 +202,9 @@ describe('MIG-156 - Test eTemplate exclusion in StudyManifestTools', () => {
     jest.spyOn(StudyManifestTools.prototype, 'getConsentManifestEntities').mockImplementation(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
     jest.spyOn(StudyManifestTools.prototype, 'getObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key))
     jest.spyOn(StudyManifestTools.prototype, 'mapObjectNameToPlural').mockImplementation(key => `${key}s`)
+    jest.spyOn(StudyManifestTools.prototype, 'getAllObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key).map(e => e._id))
+    jest.spyOn(StudyManifestTools.prototype, 'isWorkflowSupported').mockImplementation(() => true)
+    jest.spyOn(StudyManifestTools.prototype, 'getWorkflowManifestEntities').mockImplementation(() => [])
     // eslint-disable-next-line one-var, max-len
     const manifestEntities = await manifestTools.getStudyManifestEntities(org, existingStudy, {}, dummyReferences, false)
 
@@ -241,6 +244,9 @@ describe('MIG-156 - Test eTemplate exclusion in StudyManifestTools', () => {
     jest.spyOn(StudyManifestTools.prototype, 'getConsentManifestEntities').mockImplementation(() => entities.filter(o => ['ec__document_template', 'ec__default_document_css', 'ec__knowledge_check'].includes(o.object)))
     jest.spyOn(StudyManifestTools.prototype, 'getObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key))
     jest.spyOn(StudyManifestTools.prototype, 'mapObjectNameToPlural').mockImplementation(key => `${key}s`)
+    jest.spyOn(StudyManifestTools.prototype, 'getAllObjectIDsArray').mockImplementation(key => entities.filter(o => o.object === key).map(e => e._id))
+    jest.spyOn(StudyManifestTools.prototype, 'isWorkflowSupported').mockImplementation(() => true)
+    jest.spyOn(StudyManifestTools.prototype, 'getWorkflowManifestEntities').mockImplementation(() => [])
     // eslint-disable-next-line one-var, max-len
     const manifestEntities = await manifestTools.getStudyManifestEntities(org, existingStudy, {}, dummyReferences, true)
 

--- a/packages/mdctl-axon-tools/__tests__/MIG-180/MIG-180.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-180/MIG-180.test.js
@@ -1,0 +1,231 @@
+/* eslint-disable import/order */
+
+jest.mock('@medable/mdctl-api-driver', () => ({
+    Driver: class {
+    }
+}), {virtual: true})
+jest.mock('@medable/mdctl-api-driver/lib/cortex.object', () => ({
+    Object: class {
+    }, Org: class {
+    }
+}), {virtual: true})
+jest.mock('../../lib/mappings')
+
+    StudyManifestTools = require('../../lib/StudyManifestTools')
+
+describe('MIG-180 - Test Export specific workflows from a study', () => {
+
+    let manifestTools
+    const workflow = {
+        "_id": "67725gbe28e7f98ee3c8668",
+        "favorite": false,
+        "object": "wf__workflow",
+        "wf__actions": [
+            {
+                "wf__params": {
+                    "wf__notification_name": "c_axon_virtual_visit_15m_reminder"
+                },
+                "wf__type": "SITE_NOTIFICATION"
+            }
+        ],
+        "wf__conditions_exclusion": [],
+        "wf__conditions_inclusion": [
+            {
+                "wf__params": {
+                    "wf__step": "fcc78b2a-f3d3-43e9-b856-b02fef9d9595",
+                    "wf__pattern_type": "MATCH",
+                    "wf__aggregation": "AVG",
+                    "wf__period": {
+                        "wf__unit": "day",
+                        "wf__value": -2
+                    },
+                    "wf__comparison_type": "=",
+                    "wf__match_value": 1
+                },
+                "wf__type": "STEP_RESPONSE_BASED"
+            }
+        ],
+        "wf__key": "99d4d48b-1fd7-4e18-87b7-4e082e2984d2",
+        "wf__meta": {
+            "wf__active": true,
+            "wf__name": "insulin_level_alert",
+            "wf__version": "1.0.0"
+        },
+        "wf__start": {
+            "wf__params": {
+                "wf__tasks": [
+                    "c8a0106c-a2ea-4dd6-988d-45500486f9ad"
+                ],
+                "wf__offset": 0
+            },
+            "wf__type": "TASK_RESPONSE_COMPLETED"
+        }
+    }
+
+    const mockGetExportedObjects = jest.fn(() => [workflow]),
+        existingStudy = {
+            _id: '1',
+            c_name: 'Study',
+            c_key: 'abc'
+        },
+        hasNextStudyMock = jest.fn(() => true),
+        nextStudyMock = jest.fn(() => existingStudy)
+    const entities = [{
+            _id: '615bcd016631cc0100d2766c',
+            object: 'c_study',
+            c_key: 'key-001'
+        },
+            {
+                _id: '615b60d1bf2e4301008f4d68',
+                object: 'c_dummy_object',
+                c_key: 'key-002'
+            },
+            {
+                _id: '619aaaafe44c6e01003f7313',
+                object: 'c_task',
+                c_key: 'key-003'
+            },
+            {
+                _id: '61981246ca9563010037bfa8',
+                object: 'c_task',
+                c_key: 'key-004'
+            },
+            {
+                _id: '61981246ca95714c14e61a8c',
+                object: 'c_step',
+                c_key: 'key-005'
+            },
+            {
+                _id: '61981246ca966caef6108f28',
+                object: 'c_step',
+                c_key: 'key-006'
+            },
+            {
+                _id: '61981246ca9592ee0e41a3dd',
+                object: 'ec__document_template',
+                c_key: 'key-007'
+            },
+            {
+                _id: '61980eb292466ea32e087378',
+                object: 'ec__document_template',
+                c_key: 'key-008'
+            },
+            {
+                _id: '6d525cf2e328e7300d97c399',
+                object: 'ec__default_document_css',
+                c_key: 'key-009'
+            },
+            {
+                _id: '6d525cfe328e64ac0833baef',
+                object: 'ec__knowledge_check',
+                c_key: 'key-010'
+            },
+            {
+                _id: '6d525f2e328e7f1e48262523',
+                object: 'ec__knowledge_check',
+                c_key: 'key-011'
+            },
+            {
+                _id: '6d525gbed28e7f1e4826bb76',
+                object: 'c_visit_schedule',
+                c_key: 'key-012'
+            },
+            {
+                _id: '6d525gc1408e7f1e4826bb11',
+                object: 'c_visit',
+                c_key: 'key-013'
+            },
+            {
+                _id: '6d525gbe28e7fc4ff43c310',
+                object: 'c_group',
+                c_key: 'key-014'
+            },
+            {
+                _id: '67725gbe28e7f98ee3c8667',
+                object: 'c_group_task',
+                c_key: 'key-015'
+            },
+            workflow
+        ],
+        org = {
+            objects: {
+                c_study: {
+                    readOne: () => ({
+                        execute: () => ({
+                            hasNext: hasNextStudyMock,
+                            next: nextStudyMock
+                        })
+                    })
+                },
+                c_task: {
+                    find: () => ({
+                        paths: () => ({
+                            limit: () => ({
+                                toArray: () => entities.filter(e => e.object === 'c_task')
+                            })
+                        }),
+                        limit: () => ({
+                            toArray: () => entities.filter(e => e.object === 'c_task')
+                        })
+                    })
+                },
+                wf__workflow: {
+                    find: () => ({
+                        limit: () => ({
+                            toArray: () => entities.filter(e => e.object === 'wf__workflow')
+                        })
+                    })
+                },
+                object: {
+                    find: () => ({
+                        paths: () => ({
+                            toArray: () => [{uniqueKey: 'c_key'}]
+                        })
+                    })
+                }
+            }
+        }
+
+    beforeAll(async () => {
+        manifestTools = new StudyManifestTools({})
+        manifestTools.getExportObjects = mockGetExportedObjects
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('Test workflow not excluded from manifest when workflow id passed', async () => {
+        const manifestEntitiesToCompare = [
+                workflow,
+                {
+                    _id: '619aaaafe44c6e01003f7313',
+                    object: 'c_task',
+                    c_key: 'key-003'
+                },
+                {
+                    _id: '61981246ca9563010037bfa8',
+                    object: 'c_task',
+                    c_key: 'key-004'
+                },
+                {
+                    _id: '61981246ca95714c14e61a8c',
+                    object: 'c_step',
+                    c_key: 'key-005'
+                },
+                {
+                    _id: '61981246ca966caef6108f28',
+                    object: 'c_step',
+                    c_key: 'key-006'
+                }
+
+            ]
+
+        const getTaskManifestEntitiesMockFn = jest.spyOn(StudyManifestTools.prototype, 'getTaskManifestEntities').mockImplementation(() => entities.filter(o => ['c_task', 'c_step', 'c_branch'].includes(o.object)))
+        const manifestEntities = await manifestTools.getWorkflowManifestEntities(org, ['67725gbe28e7f98ee3c8668'], {})
+        expect(getTaskManifestEntitiesMockFn).toHaveBeenCalled()
+        expect(manifestEntities).toStrictEqual(manifestEntitiesToCompare)
+    })
+
+
+})

--- a/packages/mdctl-axon-tools/__tests__/MIG-85/MIG-85.test.js
+++ b/packages/mdctl-axon-tools/__tests__/MIG-85/MIG-85.test.js
@@ -268,7 +268,7 @@ describe('MIG-85 - Test partial migrations in StudyManifestTools', () => {
           expectedObjects = ['c_study', 'c_task', 'c_visit_schedule', 'ec__document_template', 'c_group', 'c_query_rule',
             'c_anchor_date_template', 'c_fault', 'c_dmweb_report', 'c_site', 'c_task_assignment', 'c_participant_schedule',
             'c_patient_flag', 'c_looker_integration_record', 'int__vendor_integration_record', 'int__model_mapping',
-            'int__pipeline', 'orac__studies', 'orac__sites', 'orac__forms', 'orac__form_questions', 'orac__events']
+            'int__pipeline', 'orac__studies', 'orac__sites', 'orac__forms', 'orac__form_questions', 'orac__events', 'wf__workflow']
 
     expect(availableObjects)
       .toStrictEqual(expectedObjects)

--- a/packages/mdctl-axon-tools/lib/StudyManifestTools.js
+++ b/packages/mdctl-axon-tools/lib/StudyManifestTools.js
@@ -12,7 +12,7 @@ const fs = require('fs'),
       packageFileDir = path.join(__dirname, '../packageScripts'),
       { Fault } = require('@medable/mdctl-core'),
       {
-        first, intersection, isObject, isArray
+        first, intersection, isObject, isArray, get: getProperty
       } = require('lodash'),
       { getMappingScript, getEcMappingScript } = require('./mappings')
 
@@ -25,11 +25,18 @@ class StudyManifestTools {
     })
   }
 
+  async isWorkflowSupported() {
+    const {org} = await this.getOrgAndReferences()
+    const client = org.driver.client
+    const workflowVersion = await client.get('/config/workflow__version')
+    return !!getProperty(workflowVersion, 'version')
+  }
+
   getAvailableObjectNames() {
     return ['c_study', 'c_task', 'c_visit_schedule', 'ec__document_template', 'c_group', 'c_query_rule',
       'c_anchor_date_template', 'c_fault', 'c_dmweb_report', 'c_site', 'c_task_assignment', 'c_participant_schedule',
       'c_patient_flag', 'c_looker_integration_record', 'int__vendor_integration_record', 'int__model_mapping',
-      'int__pipeline', 'orac__studies', 'orac__sites', 'orac__forms', 'orac__form_questions', 'orac__events']
+      'int__pipeline', 'orac__studies', 'orac__sites', 'orac__forms', 'orac__form_questions', 'orac__events', 'wf__workflow']
   }
 
   validateAndCleanManifest(manifestJSON) {
@@ -54,6 +61,10 @@ class StudyManifestTools {
           study = first(await org.objects.c_study.find().paths('_id').toArray())
 
     return study ? org.objects.c_tasks.find({ c_study: study._id }).limit(false).paths('c_name').toArray() : []
+  }
+  async getWorkflows() {
+    const org = this.getOrg()
+    return org.objects.wf__workflow.find().limit(false).paths('wf__meta.wf__name').toArray()
   }
 
   getDtConfigs() {
@@ -206,7 +217,7 @@ class StudyManifestTools {
           allEntities = await this.getStudyManifestEntities(org, study, cleanManifest, orgReferenceProps, excludeTemplates),
           { manifest, removedEntities } = this
             .validateAndCreateManifest(allEntities, orgReferenceProps, ignoreKeys)
-
+    await this.updateWorkflowDependenciesInManifest(org, orgReferenceProps, manifest)
     return {
       manifest,
       removedEntities,
@@ -257,6 +268,12 @@ class StudyManifestTools {
     this.writeToDisk('task', manifestAndDeps.removedEntities)
     return manifestAndDeps
   }
+  async getWorkflowsManifest(workflowIds) {
+    console.log('Building workflows Manifest')
+    const manifestAndDeps = await this.buildWorkflowManifestAndDependencies(workflowIds)
+    this.writeToDisk('workflow', manifestAndDeps.removedEntities)
+    return manifestAndDeps
+  }
 
   async getDtConfigsManifest(dtConfigIds) {
     const manifestAndDeps = await this.buildDtConfigManifestAndDependencies(dtConfigIds)
@@ -271,6 +288,17 @@ class StudyManifestTools {
 
     return { manifest, removedEntities }
 
+  }
+
+  async buildWorkflowManifestAndDependencies(workflowIds) {
+    const {org, orgReferenceProps} = await this.getOrgAndReferences()
+    const allEntities = await this.getWorkflowManifestEntities(org, workflowIds, orgReferenceProps)
+    const {
+      manifest,
+      removedEntities
+    } = this.validateAndCreateManifest(allEntities, orgReferenceProps, ['wf__workflows', 'c_tasks'])
+    await this.updateWorkflowDependenciesInManifest(org, orgReferenceProps, manifest)
+    return {manifest, removedEntities}
   }
 
   async buildDtConfigManifestAndDependencies(dtConfigIds) {
@@ -655,6 +683,14 @@ class StudyManifestTools {
     return data
   }
 
+  async getWorkflowNotifications(org, notificationNames) {
+    if (!notificationNames || !notificationNames.length) {
+      return []
+    }
+    const orgDetails = await org.driver.list('org')
+    return getProperty(orgDetails, 'data[0].configuration.notifications', []).filter(n => notificationNames.includes(n.name))
+  }
+
   async getExportArray(org, object, where, paths) {
 
     switch (object) {
@@ -759,6 +795,15 @@ class StudyManifestTools {
           objectAndDependencies = await this.getTaskManifestEntities(org, ids, orgReferenceProps)
           break
         }
+        case 'wf__workflow': {
+          if(!(await this.isWorkflowSupported())){
+            break
+          }
+          // Get all the workflow ID's from the org
+          ids = await this.getAllObjectIDsArray(org, key)
+          objectAndDependencies = await this.getWorkflowManifestEntities(org, ids, orgReferenceProps)
+          break
+        }
         case 'ec__document_template': {
           if (!excludeTemplates) {
             // Get the eConsents ID's from the study or the manifest
@@ -824,6 +869,10 @@ class StudyManifestTools {
     return org.objects[key].find({ [property]: { $in: values } }).limit(false).toArray()
   }
 
+  async getAllObjectIDsArray(org, key) {
+    return (await org.objects[key].find().paths('_id').limit(false).toArray()).map(wf => wf._id)
+  }
+
   async getTaskManifestEntities(org, taskIds, orgReferenceProps) {
 
     const tasks = await this.getExportObjects(org, 'c_tasks', { _id: { $in: taskIds } }, orgReferenceProps),
@@ -831,6 +880,31 @@ class StudyManifestTools {
           branches = await this.getExportObjects(org, 'c_branches', { c_task: { $in: tasks.map(v => v._id) } }, orgReferenceProps)
 
     return [...tasks, ...steps, ...branches]
+  }
+
+  async getWorkflowManifestEntities(org, workflowIds, orgReferenceProps) {
+    const workflowObjects = await org.objects.wf__workflow.find({_id: {$in: workflowIds}}).limit(false).toArray();
+    const workflowTaskKeys = workflowObjects.map(v => getProperty(v, 'wf__start.wf__params.wf__tasks')).flat()
+    const workflows = await this.getExportObjects(org, 'wf__workflows', {_id: {$in: workflowIds}}, orgReferenceProps)
+    const taskIds = await org.objects.c_task.find({c_key: {$in: workflowTaskKeys}}).paths('_id').limit(false).toArray()
+    const tasks = await this.getTaskManifestEntities(org, taskIds.map(t => t._id), orgReferenceProps)
+
+    return [...workflows, ...tasks]
+  }
+
+  async updateWorkflowDependenciesInManifest(org, orgReferenceProps, manifest) {
+    const workflowKeys = getProperty(manifest, 'wf__workflow.includes', [])
+    if(!workflowKeys.length){
+      return
+    }
+    const workflowObjects = await org.objects.wf__workflow.find({wf__key: {$in: workflowKeys}}).toArray();
+    const notificationNames = workflowObjects.map(wf => getProperty(wf, 'wf__actions', []).map(a => getProperty(a, 'wf__params.wf__notification_name')).filter(e => !!e)).flat()
+    const notifications = await this.getWorkflowNotifications(org, notificationNames, orgReferenceProps)
+    if (notifications && notifications.length) {
+      manifest.notifications = {includes: notifications.map(n => n.name)}
+      const endpoints = notifications.map(n => n.endpoints).flat()
+      manifest.templates = {includes: endpoints.map(ep => `${ep.name}.${ep.template}`)}
+    }
   }
 
   async getDtConfigManifestEntities(org, dtConfigIds, orgReferenceProps) {
@@ -907,6 +981,11 @@ class StudyManifestTools {
       case 'consent': {
         packageFile.name = 'Consent export'
         packageFile.description = 'An export of consent template or multiple consent templates'
+        break
+      }
+      case 'workflow': {
+        packageFile.name = 'Workflow export'
+        packageFile.description = 'An export of workflow or multiple workflows'
         break
       }
     }

--- a/packages/mdctl-axon-tools/packageScripts/ingestTransform.js
+++ b/packages/mdctl-axon-tools/packageScripts/ingestTransform.js
@@ -224,16 +224,19 @@ module.exports = class extends Transform {
           televisitKey = 'tv__config.version',
           integrationsKey = 'int__version.version',
           oracleKey = 'orac__version.version',
+          workflowKey = 'workflow__version.version',
           eConsentConfig = config.get(eConsentKey),
           televisitConfig = config.get(televisitKey),
           integrationsConfig = config.get(integrationsKey),
-          oracleConfig = config.get(oracleKey)
+          oracleConfig = config.get(oracleKey),
+          workflowConfig = config.get(workflowKey)
 
     return {
       eConsentConfig,
       televisitConfig,
       integrationsConfig,
-      oracleConfig
+      oracleConfig,
+      workflowConfig
     }
   }
 
@@ -250,7 +253,9 @@ module.exports = class extends Transform {
           isIntegrationsSpecfic = resource.object.startsWith('int__'),
           isIntegrationsInstalled = !!memo.availableApps.integrationsConfig,
           isOracleSpecific = resource.object.startsWith('orac__'),
-          isOracleInstalled = memo.availableApps.oracleConfig
+          isOracleInstalled = memo.availableApps.oracleConfig,
+          isWorkflowSpecific = resource.object.startsWith('wf__'),
+          isWorkflowInstalled = memo.availableApps.workflowConfig
 
     if (isEconsentSpecific && !isEconsentInstalled) {
       // eslint-disable-next-line no-undef
@@ -270,6 +275,10 @@ module.exports = class extends Transform {
     if (isOracleSpecific && !isOracleInstalled) {
       // eslint-disable-next-line no-undef
       throw Fault.create('kInvalidArgument', { reason: 'Target environment has not installed Oracle Integration, please install Oracle Integration and try again' })
+    }
+    if (isWorkflowSpecific && !isWorkflowInstalled) {
+      // eslint-disable-next-line no-undef
+      throw Fault.create('kInvalidArgument', { reason: 'Target environment has not installed Workflow Package, please install Workflow Package and try again' })
     }
 
     return true

--- a/packages/mdctl-cli/lib/studyQuestions.js
+++ b/packages/mdctl-cli/lib/studyQuestions.js
@@ -1,4 +1,5 @@
 const { prompt } = require('inquirer'),
+      _ = require('lodash')
 
       askSelectTasks = async(inputArgs) => {
         // eslint-disable-next-line no-underscore-dangle
@@ -11,6 +12,19 @@ const { prompt } = require('inquirer'),
               }])
 
         return result.selectedTasks
+      },
+
+      askSelectWorkflows = async({ workflows }) => {
+        // eslint-disable-next-line no-underscore-dangle
+        const choices = workflows.map(v => ({ name: _.get(v, 'wf__meta.wf__name'), value: v._id })),
+              result = await prompt([{
+                type: 'checkbox',
+                name: 'selectedWorkflows',
+                message: 'Please Select the workflows you wish to export',
+                choices
+              }])
+
+        return result.selectedWorkflows
       },
 
       askSelectConsentTemplates = async(inputArgs) => {
@@ -41,6 +55,7 @@ const { prompt } = require('inquirer'),
 
 module.exports = {
   askSelectTasks,
+  askSelectWorkflows,
   askSelectConsentTemplates,
   askSelectDtConfigs
 }

--- a/packages/mdctl-import-adapter/__tests__/MIG-121/template-export/ingestTransform.js
+++ b/packages/mdctl-import-adapter/__tests__/MIG-121/template-export/ingestTransform.js
@@ -224,16 +224,19 @@ module.exports = class extends Transform {
           televisitKey = 'tv__config.version',
           integrationsKey = 'int__version.version',
           oracleKey = 'orac__version.version',
+          workflowKey = 'workflow__version.version',
           eConsentConfig = config.get(eConsentKey),
           televisitConfig = config.get(televisitKey),
           integrationsConfig = config.get(integrationsKey),
-          oracleConfig = config.get(oracleKey)
+          oracleConfig = config.get(oracleKey),
+          workflowConfig = config.get(workflowKey)
 
     return {
       eConsentConfig,
       televisitConfig,
       integrationsConfig,
-      oracleConfig
+      oracleConfig,
+      workflowConfig
     }
   }
 
@@ -250,7 +253,9 @@ module.exports = class extends Transform {
           isIntegrationsSpecfic = resource.object.startsWith('int__'),
           isIntegrationsInstalled = !!memo.availableApps.integrationsConfig,
           isOracleSpecific = resource.object.startsWith('orac__'),
-          isOracleInstalled = memo.availableApps.oracleConfig
+          isOracleInstalled = memo.availableApps.oracleConfig,
+          isWorkflowSpecific = resource.object.startsWith('wf__'),
+          isWorkflowInstalled = memo.availableApps.workflowConfig
 
     if (isEconsentSpecific && !isEconsentInstalled) {
       // eslint-disable-next-line no-undef
@@ -270,6 +275,10 @@ module.exports = class extends Transform {
     if (isOracleSpecific && !isOracleInstalled) {
       // eslint-disable-next-line no-undef
       throw Fault.create('kInvalidArgument', { reason: 'Target environment has not installed Oracle Integration, please install Oracle Integration and try again' })
+    }
+    if (isWorkflowSpecific && !isWorkflowInstalled) {
+      // eslint-disable-next-line no-undef
+      throw Fault.create('kInvalidArgument', { reason: 'Target environment has not installed Workflow Package, please install Workflow Package and try again' })
     }
 
     return true


### PR DESCRIPTION
This PR provides the options to export/import the  workflow objects.

Changes:

- New study command to selective export of workflow object
- Import feature of workflow object
- Study export includes workflow object only if `workflow__version` config is present

Commands: 

```
mdctl study workflows export
mdctl study import
```
