### PR TITLE
CTXTOOLS-122: Adding support for includes: ['*'] at top level for import.

### DIFF
--- a/packages/mdctl-import-adapter/index.js
+++ b/packages/mdctl-import-adapter/index.js
@@ -274,9 +274,14 @@ class ImportFileTreeAdapter extends EventEmitter {
           })
         }
       } else if (manifestData[k] instanceof Array) {
-        manifestData[k].forEach((o) => {
-          paths.push(`env/${k}/**/${o.name}.{json,yaml}`)
-        })
+        if(k === 'includes' && manifestData[k][0] === '*') {
+          // adding all resources availables inside env/ folder
+          paths.push('env/**/*.{json,yaml}')
+        } else {
+          manifestData[k].forEach((o) => {
+            paths.push(`env/${k}/**/${o.name}.{json,yaml}`)
+          })
+        }
       }
     }
     this.walkFiles(input, paths)


### PR DESCRIPTION
- Adding changes in readManifest to support `includes: ['*']` at top level which means all resources inside env/ folder.