### PR TITLE
detect end of export stream

### DIFF
--- a/packages/mdctl-core/streams/export_stream.js
+++ b/packages/mdctl-core/streams/export_stream.js
@@ -11,6 +11,11 @@ class ExportStream extends Transform {
       objectMode: true
     }, options))
     this.runtimes = []
+    this.completed = false
+  }
+
+  complete() {
+    return this.completed
   }
 
   checkKeys(name) {
@@ -24,6 +29,9 @@ class ExportStream extends Transform {
     } else if (chunk.object === 'fault') {
       callback(Fault.from(chunk))
     } else {
+      if (chunk.object === 'manifest-exports') {
+        this.completed = true
+      }
       if (this.checkKeys(chunk.object)) {
         const section = new ExportSection(chunk, chunk.object)
         this.push(section)


### PR DESCRIPTION
This MR introduces a mechanism to detect stream termination, aiming to provide a clearer distinction between streams that end normally and those terminated due to the process being killed unexpectedly. 

The last thing cortex-api emits in an export is the `manifest-exports` object, which will always be present in an export. Receiving this object signals the end of the stream.