### PR TITLE
mdctl-core tests

### DIFF
--- a/.github/workflows/mdctl-core-tests.yml
+++ b/.github/workflows/mdctl-core-tests.yml
@@ -1,0 +1,30 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Mdctl core Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run test --workspace=@medable/mdctl-core

--- a/packages/mdctl-cli/lib/env/export.js
+++ b/packages/mdctl-cli/lib/env/export.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 const { Transform } = require('stream')
 
 const fs = require('fs'),

--- a/packages/mdctl-cli/lib/studyQuestions.js
+++ b/packages/mdctl-cli/lib/studyQuestions.js
@@ -1,5 +1,5 @@
 const { prompt } = require('inquirer'),
-      _ = require('lodash')
+      _ = require('lodash'),
 
       askSelectTasks = async(inputArgs) => {
         // eslint-disable-next-line no-underscore-dangle

--- a/packages/mdctl-cli/tasks/study.js
+++ b/packages/mdctl-cli/tasks/study.js
@@ -1,3 +1,4 @@
+/* eslint-disable one-var */
 /* eslint-disable class-methods-use-this */
 
 const _ = require('lodash'),
@@ -162,13 +163,14 @@ class Study extends Task {
 
 
   }
+
   async 'study@workflows'(cli) {
     const client = await cli.getApiClient({ credentials: await cli.getAuthOptions() }),
           params = await cli.getArguments(this.optionKeys),
           studyTools = new StudyManifestTools(client, params),
           action = this.args('2')
     if (!(await studyTools.isWorkflowSupported())) {
-      throw Fault.create('kInvalidArgument', {reason: 'Target environment has not installed Workflow Package, please install Workflow Package and try again'})
+      throw Fault.create('kInvalidArgument', { reason: 'Target environment has not installed Workflow Package, please install Workflow Package and try again' })
     }
 
     if (!action) {
@@ -181,7 +183,9 @@ class Study extends Task {
         throw workflows[0]
       }
       const selectedWorkflows = await askSelectWorkflows({ workflows })
-      if (!selectedWorkflows.length) throw Fault.create('kInvalidArgument', { reason: 'No Workflows selected' })
+      if (!selectedWorkflows.length) {
+        throw Fault.create('kInvalidArgument', { reason: 'No Workflows selected' })
+      }
       const { manifest } = await studyTools.getWorkflowsManifest(selectedWorkflows)
 
 

--- a/packages/mdctl-core/fault.js
+++ b/packages/mdctl-core/fault.js
@@ -76,6 +76,7 @@ class Fault extends Error {
     return this.reason || ''
   }
 
+  // eslint-disable-next-line max-len
   static normalizeOptions(input, msg, statusCode, name, reason, path, faults, trace, index, resource) {
 
     let obj,

--- a/packages/mdctl-core/test/export_stream.test.js
+++ b/packages/mdctl-core/test/export_stream.test.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-underscore-dangle */
+const assert = require('assert'),
+      sinon = require('sinon'),
+      ExportStream = require('../streams/export_stream'),
+      Fault = require('../fault'),
+      { ExportSection, StreamChunk } = require('../streams/section')
+
+describe('ExportStream', () => {
+  let exportStream
+
+  beforeEach(() => {
+    exportStream = new ExportStream()
+  })
+
+  it('should initialize with empty runtimes array and completed set to false', () => {
+    assert.deepStrictEqual(exportStream.runtimes, [])
+    assert.strictEqual(exportStream.completed, false)
+  })
+
+  it('should return the value of completed property', () => {
+    assert.strictEqual(exportStream.complete(), false)
+    exportStream.completed = true
+    assert.strictEqual(exportStream.complete(), true)
+  })
+
+  it('should check if a given name is in the allowed keys', () => {
+    assert.strictEqual(exportStream.checkKeys('object'), true)
+    assert.strictEqual(exportStream.checkKeys('facet'), true)
+    assert.strictEqual(exportStream.checkKeys('app'), true)
+    assert.strictEqual(exportStream.checkKeys('config'), true)
+    assert.strictEqual(exportStream.checkKeys('invalid-key'), false)
+  })
+
+  it('should transform and push ExportSection when the object is in the allowed keys', () => {
+    const chunk = { object: 'object' },
+          pushSpy = sinon.spy(exportStream, 'push')
+
+    exportStream._transform(chunk, null, () => {})
+
+    sinon.assert.calledWith(pushSpy, new ExportSection(chunk, chunk.object))
+  })
+
+  it('should transform and push StreamChunk when the object is "stream"', () => {
+    const chunk = { object: 'stream' },
+          pushSpy = sinon.spy(exportStream, 'push')
+
+    exportStream._transform(chunk, null, () => {})
+
+    sinon.assert.calledWith(pushSpy, new StreamChunk(chunk, chunk.object))
+  })
+
+  it('should add runtime chunk to the runtimes array when the object is "runtime-resource"', () => {
+    const chunk = { object: 'runtime-resource' }
+
+    exportStream._transform(chunk, null, () => {})
+
+    assert(exportStream.runtimes.includes(chunk))
+  })
+
+  it('should set completed to true when the object is "manifest-exports"', () => {
+    const chunk = { object: 'manifest-exports' }
+
+    exportStream._transform(chunk, null, () => {})
+
+    assert.strictEqual(exportStream.completed, true)
+  })
+
+  it('should callback with a Fault when the chunk does not have an object property', () => {
+    const callback = sinon.stub()
+
+    exportStream._transform({}, null, callback)
+
+    sinon.assert.calledWith(callback, sinon.match.instanceOf(Fault))
+  })
+
+  it('should callback with a Fault when the chunk object is "fault"', () => {
+    const chunk = { object: 'fault' },
+          callback = sinon.stub()
+
+    exportStream._transform(chunk, null, callback)
+
+    sinon.assert.calledWith(callback, sinon.match.instanceOf(Fault))
+  })
+
+  it('should ignore unhandled chunks', () => {
+    const chunk = { object: 'unhandled' },
+          callback = sinon.stub()
+
+    exportStream._transform(chunk, null, callback)
+
+    sinon.assert.calledWith(callback)
+  })
+
+  it('should flush the runtimes array as an ExportSection', () => {
+    const done = sinon.stub(),
+          pushSpy = sinon.spy(exportStream, 'push')
+
+    exportStream.runtimes = [{ object: 'runtime-resource' }]
+
+    exportStream._flush(done)
+
+    sinon.assert.calledWith(pushSpy, new ExportSection(exportStream.runtimes, 'resources'))
+    sinon.assert.called(done)
+  })
+})


### PR DESCRIPTION
This PR adds a workflow to run mdctl-core package tests in CI and adds tests covering export_stream.js
Also fixes some lint issues in mdctl-cli package.