### PR TITLE
Updates mdctl study documentation to list the correct tasks command

### DIFF
--- a/packages/mdctl-cli/tasks/study.js
+++ b/packages/mdctl-cli/tasks/study.js
@@ -356,7 +356,7 @@ class Study extends Task {
       Command
         export - Exports the study from the current org
         import - Imports the study into the current org
-        task [action] - Allows the select of tasks to export from the current org
+        tasks [action] - Allows the select of tasks to export from the current org
         consent [action] - Allows the select of consent templates to export from the current org
         workflow [action] - Allows the select of workflow templates to export from the current org
         data-transfer - Allows the select of data transfer configs to export from the current org


### PR DESCRIPTION
**Current `mdctl study` documentation**
```
 ~/github/Medable/mdctl  update_study_tasks_documentation ................................ direnv  system node  impure nix  11:25:23
> mdctl help study

    Study Tools

    Usage:

      mdctl study [command]

    Arguments:

      Command
        export - Exports the study from the current org
        import - Imports the study into the current org
        task [action] - Allows the select of tasks to export from the current org
        consent [action] - Allows the select of consent templates to export from the current org
        workflow [action] - Allows the select of workflow templates to export from the current org
        data-transfer - Allows the select of data transfer configs to export from the current org
```

**Current behavior for `task` command**
```
> mdctl study task --env env.orgCode
{
  object: 'fault',
  name: 'error',
  errCode: 'mdctl.error.unspecified',
  code: 'kError',
  message: 'Invalid command',
  status: 500,
  trace: null,
  path: undefined,
  resource: undefined,
  reason: undefined
}
```

**New documentation**
```
 ~/github/Medable/mdctl/packages/mdctl-cli  update_study_tasks_documentation !1 ...... 4s  direnv  system node  impure nix  11:29:52
> node cli.js help study

    Study Tools

    Usage:

      mdctl study [command]

    Arguments:

      Command
        export - Exports the study from the current org
        import - Imports the study into the current org
        tasks [action] - Allows the select of tasks to export from the current org
        consent [action] - Allows the select of consent templates to export from the current org
        workflow [action] - Allows the select of workflow templates to export from the current org
        data-transfer - Allows the select of data transfer configs to export from the current org
```