### PR TITLE
MIG_207: omit script extraction from i18n objects

### DIFF
--- a/packages/mdctl-core/streams/section.js
+++ b/packages/mdctl-core/streams/section.js
@@ -238,7 +238,7 @@ class ExportSection {
           nodes = jp.nodes(content, '$..script')
 
     // Exclude script extraction to all instance data.
-    if (isCustomName(content.object)) {
+    if (isCustomName(content.object) || content.object === 'i18n') {
       return
     }
 


### PR DESCRIPTION
We need to omit i18n objects from script extraction since it evaluates keys and if contains keys with script key will change the file structure.