### PR TITLE
When running env import, add a default "objects" property to the package object

### DIFF
--- a/packages/mdctl-import-adapter/index.js
+++ b/packages/mdctl-import-adapter/index.js
@@ -7,7 +7,7 @@ const EventEmitter = require('events'),
       _ = require('lodash'),
       pluralize = require('pluralize'),
       { ImportSection } = require('@medable/mdctl-core/streams/section'),
-      { parseString, isCustomName } = require('@medable/mdctl-core-utils/values'),
+      { isSet, parseString, isCustomName } = require('@medable/mdctl-core-utils/values'),
       { md5FileHash } = require('@medable/mdctl-node-utils/crypto'),
       { privatesAccessor } = require('@medable/mdctl-core-utils/privates'),
       { OutputStream } = require('@medable/mdctl-core/streams/chunk-stream'),
@@ -102,8 +102,11 @@ class ImportFileTreeAdapter extends EventEmitter {
 
   async loadPackageFromObject() {
     const { packageData, input, format } = privatesAccessor(this),
-          section = new ImportSection(packageData, 'package', `package.${format}`, input)
-    return { results: [section.content], blobResults: [] }
+          { content } = new ImportSection(packageData, 'package', `package.${format}`, input)
+    if (!isSet(content.object)) {
+      content.object = 'package'
+    }
+    return { results: [content], blobResults: [] }
   }
 
   async loadFileContent(f) {


### PR DESCRIPTION
The `mdctl env import` command fails with the following error when run in the same directory as a `package.json` file which doesn't have an `"object"` property:

```
  object: 'fault',
  name: 'error',
  errCode: 'cortex.invalidArgument.unspecified',
  code: 'kInvalidArgument',
  message: 'Invalid Argument',
  status: 400,
  trace: undefined,
  path: undefined,
  resource: undefined,
  reason: 'The resource is missing the object property.',
  index: 0
```

The current workaround when this happens is to delete the package file.

This PR provides a fix by ensuring that an object loaded from a `package.json` file has an `object` property defaulted to the value `package`.